### PR TITLE
:wastebasket: Add support for compatibility SuppressDependenciesWhenPacking property

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
@@ -9,6 +9,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 This file brings SDK Pack compatibility conversions so that NuGetizer works with SDK Pack 
 properties and items as much as possible, to ease migration.
 
+NOTE: this file is imported from NuGetizer.Shared.targets, so it comes *after* project 
+properties.
+
 Copyright (c) .NET Foundation. All rights reserved. 
 ***********************************************************************************************
 -->
@@ -23,12 +26,20 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackCompile Condition="'$(PackCompile)' == '' and '$(IncludeSource)' != ''">$(IncludeSource)</PackCompile>
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IncludeBuildOutput)' != ''">$(IncludeBuildOutput)</PackBuildOutput>
     <Description Condition="'$(Description)' == '' and '$(PackageDescription)' != ''">$(PackageDescription)</Description>
+
+    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(SuppressDependenciesWhenPacking)' == 'true'">false</PackFrameworkReferences>
   </PropertyGroup>
+
+  <ItemDefinitionGroup Condition="'$(SuppressDependenciesWhenPacking)' == 'true'">
+    <PackageReference>
+      <Pack>false</Pack>
+    </PackageReference>
+  </ItemDefinitionGroup>
 
   <PropertyGroup Label="Legacy NuGetizer Compat">
     <PackFolder Condition="'$(PackFolder)' == '' and '$(BuildOutputKind)' != ''">$(BuildOutputKind)</PackFolder>
     <PackFolder Condition="'$(PackFolder)' == '' and '$(PrimaryOutputKind)' != ''">$(PrimaryOutputKind)</PackFolder>
-    
+
     <PackContent Condition="'$(PackContent)' == '' and '$(IncludeContentInPackage)' != ''">$(IncludeContentInPackage)</PackContent>
     <PackNone Condition="'$(PackNone)' == '' and '$(IncludeNoneInPackage)' != ''">$(IncludeNoneInPackage)</PackNone>
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IncludeOutputsInPackage)' != ''">$(IncludeOutputsInPackage)</PackBuildOutput>

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -123,6 +123,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemDefinitionGroup>
     <PackageReference>
       <Pack />
+      <Pack Condition="'$(SuppressDependenciesWhenPacking)' == 'true'">false</Pack>
       <PrivateAssets />
     </PackageReference>
     <ImplicitPackageReference>

--- a/src/NuGetizer.Tests/given_packagereferences.cs
+++ b/src/NuGetizer.Tests/given_packagereferences.cs
@@ -131,6 +131,62 @@ namespace NuGetizer
         }
 
         [Fact]
+        public void when_SuppressDependenciesWhenPacking_then_does_not_pack()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <PackageId>Library</PackageId>
+    <TargetFramework>net472</TargetFramework>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include='WindowsBase' />
+    <PackageReference Include='Newtonsoft.Json' Version='1.0.0' />
+  </ItemGroup>
+</Project>",
+                "GetPackageContents", output);
+
+            result.AssertSuccess(output);
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Newtonsoft.Json"
+            }));
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "WindowsBase"
+            }));
+        }
+
+        [Fact]
+        public void when_SuppressDependenciesWhenPackingFalse_then_packs()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <PackageId>Library</PackageId>
+    <TargetFramework>net472</TargetFramework>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include='WindowsBase' />
+    <PackageReference Include='Newtonsoft.Json' Version='1.0.0' />
+  </ItemGroup>
+</Project>",
+                "GetPackageContents", output);
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Newtonsoft.Json"
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "WindowsBase"
+            }));
+        }
+
+        [Fact]
         public void when_build_kind_then_does_not_pack_msbuild()
         {
             var result = Builder.BuildProject(@"


### PR DESCRIPTION
From NuGet/Home#6354, the SuppressDependenciesWhenPacking property can turn off package reference and framework reference dependencies inference in SDK pack.

This adds compatibility behavior that turns off packing of PackageReference by default when that flag is true, as well as framework references.

The individual package references can still opt in even when the setting is true.

Fixes #67