### PR TITLE
Add support for opting out of dependencies packing

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
@@ -25,16 +25,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackContent Condition="'$(PackContent)' == '' and '$(IncludeContentInPack)' != ''">$(IncludeContentInPack)</PackContent>
     <PackCompile Condition="'$(PackCompile)' == '' and '$(IncludeSource)' != ''">$(IncludeSource)</PackCompile>
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IncludeBuildOutput)' != ''">$(IncludeBuildOutput)</PackBuildOutput>
+    <PackDependencies Condition="'$(PackDependencies)' == '' and '$(SuppressDependenciesWhenPacking)' == 'true'">false</PackDependencies>
+
     <Description Condition="'$(Description)' == '' and '$(PackageDescription)' != ''">$(PackageDescription)</Description>
-
-    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(SuppressDependenciesWhenPacking)' == 'true'">false</PackFrameworkReferences>
   </PropertyGroup>
-
-  <ItemDefinitionGroup Condition="'$(SuppressDependenciesWhenPacking)' == 'true'">
-    <PackageReference>
-      <Pack>false</Pack>
-    </PackageReference>
-  </ItemDefinitionGroup>
 
   <PropertyGroup Label="Legacy NuGetizer Compat">
     <PackFolder Condition="'$(PackFolder)' == '' and '$(BuildOutputKind)' != ''">$(BuildOutputKind)</PackFolder>

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -24,6 +24,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackSymbols Condition="'$(PackSymbols)' == '' and '$(PackBuildOutput)' == 'true'">true</PackSymbols>
 
     <!-- Whether to include framework references (%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}') in the package -->
+    <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(PackDependencies)' == 'false'">false</PackFrameworkReferences>
     <!-- Only default to true if the project isn't a nuget packaging project itself and its primary output is lib. -->
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IsPackagingProject)' != 'true' and '$(PackFolder)' == 'lib'">true</PackFrameworkReferences>
 
@@ -123,11 +124,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemDefinitionGroup>
     <PackageReference>
       <Pack />
-      <Pack Condition="'$(SuppressDependenciesWhenPacking)' == 'true'">false</Pack>
+      <Pack Condition="'$(PackDependencies)' == 'false'">false</Pack>
       <PrivateAssets />
     </PackageReference>
     <ImplicitPackageReference>
       <Pack />
+      <Pack Condition="'$(PackDependencies)' == 'false'">false</Pack>
       <PrivateAssets />
     </ImplicitPackageReference>
     <ReferencePath>

--- a/src/NuGetizer.Tests/given_packagereferences.cs
+++ b/src/NuGetizer.Tests/given_packagereferences.cs
@@ -131,6 +131,35 @@ namespace NuGetizer
         }
 
         [Fact]
+        public void when_pack_dependencies_false_then_does_not_pack()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <PackageId>Library</PackageId>
+    <TargetFramework>net472</TargetFramework>
+    <PackDependencies>false</PackDependencies>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include='System.Numerics' />
+    <PackageReference Include='Microsoft.NETFramework.ReferenceAssemblies' Version='1.0.0' />
+    <PackageReference Include='Newtonsoft.Json' Version='1.0.0' />
+  </ItemGroup>
+</Project>",
+                "GetPackageContents", output);
+
+            result.AssertSuccess(output);
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Newtonsoft.Json"
+            }));
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "System.Numerics"
+            }));
+        }
+
+        [Fact]
         public void when_SuppressDependenciesWhenPacking_then_does_not_pack()
         {
             var result = Builder.BuildProject(@"


### PR DESCRIPTION
The new PackDependencies property (defaults to empty, meaning `true`) can be set to `false` which is equivalent to setting `SuppressDependenciesWhenPacking=true`.

This allows quickly and easily opting out of PackageReference (defaults all item's Pack metadata to false) as well as framework references.

Fixes #73.