### PR TITLE
If short SHA is available, use it for package metadata

### DIFF
--- a/src/NuGetizer.Tasks/CreatePackage.cs
+++ b/src/NuGetizer.Tasks/CreatePackage.cs
@@ -141,6 +141,9 @@ namespace NuGetizer.Tasks
             if (Manifest.TryGetMetadata("RepositoryCommit", out var repoCommit))
                 (metadata.Repository ??= new RepositoryMetadata()).Commit = repoCommit;
 
+            if (Manifest.TryGetMetadata("RepositorySha", out var repoSha))
+                (metadata.Repository ??= new RepositoryMetadata()).Commit = repoSha;
+
             if (!string.IsNullOrEmpty(Manifest.GetMetadata("ProjectUrl")))
                 metadata.SetProjectUrl(Manifest.GetMetadata("ProjectUrl"));
 

--- a/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
@@ -48,6 +48,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <RepositoryUrl Condition="'$(RepositoryUrl)' != ''">$(RepositoryUrl)</RepositoryUrl>
       <RepositoryBranch Condition="'$(RepositoryBranch)' != ''">$(RepositoryBranch)</RepositoryBranch>
       <RepositoryCommit Condition="'$(RepositoryCommit)' != ''">$(RepositoryCommit)</RepositoryCommit>
+      <!-- This item metadata will override the RepositoryCommit in package metadata -->
+      <RepositorySha Condition="'$(UseShortSourceRevisionId)' != 'false' and '$(RepositorySha)' != ''">$(RepositorySha)</RepositorySha>
     </PackageMetadata>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
The short SHA (9-char version) is sufficiently unique for use to retrieve the upstream commit/tree.

Whenever the short sha is available, we should use that instead. An opt-out property UseShortSourceRevisionId allows turning off this behavior.

Fixes #94