### PR TITLE
Allow specifying PackFolder in ProjectReference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -270,6 +270,18 @@ Package: Sample.1.0.0.nupkg
         sample.pdb
 ```
 
+If you need to tweak target folder of a referenced project, you can also do so 
+via the `PackFolder` attribute on the `ProjectReference` itself:
+
+```xml
+   <ProjectReference Include="..\MyDesktopLibrary\MyDesktopLibrary.csproj" 
+                     PackFolder="lib\net5.0\SpecificFolder" />
+```
+
+> NOTE: this is a convenience shortcut since you can already pass additional project 
+> properties for project references using the built-in 
+> [`AdditionalProperties` attribute](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-task?view=vs-2019#pass-properties-to-projects).
+
 Finally, you can focedly turn a project reference build output into a private asset even if it defines a `PackageId` by adding `PrivateAssets=all`. This is very useful for build and analyzer packages, which typically reference the main library project too, but need its output as private, since neither can use dependencies at run-time.
 
 ## Advanced Features

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -9,7 +9,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved. 
 ***********************************************************************************************
 -->
-<Project InitialTargets="_SetPropertiesFromCapabilities" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project InitialTargets="_SetPropertiesFromCapabilities" TreatAsLocalProperty="PackFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="NuGetizer.Tasks.AssignPackagePath" AssemblyFile="NuGetizer.Tasks.dll" />
   <UsingTask TaskName="NuGetizer.Tasks.WriteItemsToFile" AssemblyFile="NuGetizer.Tasks.dll" />
 
@@ -154,6 +154,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                          %(_NuGetizedProjectReference.SetPlatform); 
                          %(_NuGetizedProjectReference.SetTargetFramework); 
                          BuildingPackage=$(BuildingPackage); 
+                         PackFolder=%(_NuGetizedProjectReference.PackFolder);
                          DesignTimeBuild=false"
              Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
              RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">

--- a/src/NuGetizer.Tests/given_projectreferences.cs
+++ b/src/NuGetizer.Tests/given_projectreferences.cs
@@ -217,5 +217,61 @@ namespace NuGetizer
             }));
         }
 
+        [Fact]
+        public void when_projectreference_explicit_packfolder_then_specific_folder_is_packed()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.0.4'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include='Library.csproj' AdditionalProperties='PackFolder=lib\net5.0\SpecificFolder' />
+  </ItemGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("Library.csproj", @"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+</Project>"));
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"lib\net5.0\SpecificFolder\Library.dll",
+            }));
+        }
+
+        [Fact]
+        public void when_projectreference_has_packfolder_metadata_then_specific_folder_is_packed()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.0.4'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include='Library.csproj' PackFolder='lib\net5.0\SpecificFolder' />
+  </ItemGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("Library.csproj", @"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+</Project>"));
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"lib\net5.0\SpecificFolder\Library.dll",
+            }));
+        }
+
     }
 }


### PR DESCRIPTION
This is far simpler and more aligned with the way we allow PackFolder on almost any item.

Fixes #124 and improves on #118.