### PR TITLE
Skip non-nugetized projects when nugetizer runs for solution

### DIFF
--- a/src/dotnet-nugetize/EmbeddedResource.cs
+++ b/src/dotnet-nugetize/EmbeddedResource.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+static class EmbeddedResource
+{
+    static readonly string baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+    public static string GetContent(string relativePath)
+    {
+        var filePath = Path.Combine(baseDir, Path.GetFileName(relativePath));
+        if (File.Exists(filePath))
+            return File.ReadAllText(filePath);
+
+        var baseName = Assembly.GetExecutingAssembly().GetName().Name;
+        var resourceName = relativePath
+            .TrimStart('.')
+            .Replace(Path.DirectorySeparatorChar, '.')
+            .Replace(Path.AltDirectorySeparatorChar, '.');
+
+        var manifestResourceName = Assembly.GetExecutingAssembly()
+            .GetManifestResourceNames().FirstOrDefault(x => x.EndsWith(resourceName));
+
+        if (string.IsNullOrEmpty(manifestResourceName))
+            throw new InvalidOperationException($"Did not find required resource ending in '{resourceName}' in assembly '{baseName}'.");
+
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream(manifestResourceName);
+
+        if (stream == null)
+            throw new InvalidOperationException($"Did not find required resource '{manifestResourceName}' in assembly '{baseName}'.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/dotnet-nugetize/after.sln.targets
+++ b/src/dotnet-nugetize/after.sln.targets
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RemoveNonNuGetized" BeforeTargets="GetPackageContents">
+    <MSBuild Properties="BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)" 
+             BuildInParallel="True" 
+             SkipNonexistentProjects="%(ProjectReference.SkipNonexistentProjects)" 
+             Targets="GetTargetPath" 
+             Projects="@(ProjectReference)">
+      <Output TaskParameter="TargetOutputs" ItemName="ReferencedProjectTargetPath" />
+    </MSBuild>
+    <ItemGroup>
+      <NuGetizedTargetPath Include="@(ReferencedProjectTargetPath -> WithMetadataValue('IsNuGetized', 'true'))" />
+      <NonNuGetizedTargetPath Include="@(ReferencedProjectTargetPath)" Exclude="@(NuGetizedTargetPath)" />
+      <ProjectReference Remove="@(NonNuGetizedTargetPath -> '%(MSBuildSourceProjectFile)')" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/dotnet-nugetize/dotnet-nugetize.csproj
+++ b/src/dotnet-nugetize/dotnet-nugetize.csproj
@@ -29,6 +29,8 @@
   <ItemGroup>
     <None Update="NuGetize.Build.targets" CopyToOutputDirectory="PreserveNewest" />
     <Compile Remove="Range.cs" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <None Remove="after.sln.targets" />
+    <EmbeddedResource Include="after.sln.targets" CopyToOutputDirectory="PreserveNewest" />
     <ProjectProperty Include="Version" />
     <ProjectProperty Include="ToolCommandName" />
     <ProjectProperty Include="Product" />    


### PR DESCRIPTION
Rather than failing ungracefully, just skip those project where we can safely detect nugetizer isn't installed.

Fixes #107