### PR TITLE
A few fixes for cleanup targets

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
@@ -16,7 +16,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- We clean the HTTP cache by default. This does *not* clear the cached installed packages -->
     <CleanHttpNuGetCacheOnPack Condition="'$(CleanHttpNuGetCacheOnPack)' == ''">true</CleanHttpNuGetCacheOnPack>
     <!-- The actual NuGet cache is only cleared for the *current* PackageId, so no need to turn off its clearing on build/pack -->
-    <NuGetCache>$(UserProfile)\.nuget\packages</NuGetCache>
+    <NuGetCache Condition="'$(NuGetCache)' == ''">$(UserProfile)\.nuget\packages</NuGetCache>
     <PackDependsOn>
       CleanPackageOutput;
       $(PackDependsOn);

--- a/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
@@ -55,4 +55,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Exec Command='rm -rf "$(HttpNuGetCache)"' Condition="'$(OS)' != 'Windows_NT'" />
   </Target>
 
+  <!-- Remove packages when clean -->
+  <Target Name="IncrementalCleanPackageOutput"
+          DependsOnTargets="CleanPackageOutput"
+          BeforeTargets="BeforeClean" />
+
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
@@ -27,7 +27,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_ExistingPackage Include="$(PackageOutputPath)\$(PackageId)*.nupkg" />
       <_PackageToDelete Include="@(_ExistingPackage)" 
-                        Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '$(PackageId)\.\d\.\d\.\d.*'))" />
+                        Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '$(PackageId)\.\d+\.\d+\.\d+.*'))" />
     </ItemGroup>
     <Delete Files="@(_PackageToDelete)" ContinueOnError="true">
       <Output TaskParameter="DeletedFiles" ItemName="_CleanedPackages" />


### PR DESCRIPTION
Hi,

Thank you very much for this fantastic tool, it's so much easier to create complex NuGet packages with this tool.

When I applied it to my projects, I found  a few small issues with incremental build: NuGetizer fails to clean generated NuGet packages in some cases:

- When version components contain more than one digits, like "11.22.33";
- When "PackageOutputPath" has been set to locations outside of intermediate directory.

I also find it's very difficult to change NuGet cache location, which I usually pointed to a non-default one for testing purpose.

I fixed all those issues in this pull request, tested with my projects. Please have a check.

Regards!

Guopeng