### PR TITLE
Fix contentFiles relative path in manifest

### DIFF
--- a/src/NuGetizer.Tasks/Extensions.cs
+++ b/src/NuGetizer.Tasks/Extensions.cs
@@ -54,11 +54,11 @@ namespace NuGetizer
 
         public static string GetContentFileInclude(this ITaskItem taskItem)
         {
-            const string contentFilesFolder = @"contentFiles\";
             var include = taskItem.GetMetadata(MetadataName.PackagePath);
-            if (include.StartsWith(contentFilesFolder))
-                return include.Substring(contentFilesFolder.Length);
-            return include;
+            if (include.StartsWith("contentFiles"))
+                include = include.Substring(12);
+
+            return include.TrimStart('/', '\\');
         }
 
         public static Manifest GetManifest(this IPackageCoreReader packageReader)


### PR DESCRIPTION
We had code to account for [this scenario](https://github.com/dotnet/sdk/issues/9718#issuecomment-419390506) but it wasn't working properly because we included the backslash (which in non-Windows might not even be there), so we improve the partial path detection and it should now work as expected.

Fixes #143