### PR TITLE
Allow specifying that packaging projects are framework specific

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -126,7 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackFolder>Metadata</PackFolder>
         <PackageId>$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
       </PackageFile>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
For cases where you know you'll be authoring a package you want to only target to a specific framework, you are now able to specify so by setting `BuildOutputFrameworkSpecific=true` in the project.

Alternatively, you can also annotate a project reference to the packaging project with the TFM you want it to "pack for" as:

```xml
<ProjectReference Include="Common.msbuildproj" TargetFramework="net6.0"
```

Fixes #155