### PR TITLE
Be smarter about PackFolder on project references

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -43,6 +43,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <ItemDefinitionGroup>
+    <_MSBuildProjectReferenceExistent>
+      <!-- Allows referencing this metadata value even if not defined anywhere -->
+      <PackFolder />
+    </_MSBuildProjectReferenceExistent>
     <PackageReference>
       <!-- This enables referencing arbitrary files from any package by adding PackageReference="" to a file -->
       <GeneratePathProperty>true</GeneratePathProperty>

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -153,8 +153,8 @@ Copyright (c) .NET Foundation. All rights reserved.
              Properties="%(_NuGetizedProjectReference.SetConfiguration); 
                          %(_NuGetizedProjectReference.SetPlatform); 
                          %(_NuGetizedProjectReference.SetTargetFramework); 
+                         %(_NuGetizedProjectReference.SetPackFolder);
                          BuildingPackage=$(BuildingPackage); 
-                         PackFolder=%(_NuGetizedProjectReference.PackFolder);
                          DesignTimeBuild=false"
              Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_NuGetizedProjectReference)' != ''"
              RemoveProperties="%(_NuGetizedProjectReference.GlobalPropertiesToRemove)">
@@ -259,6 +259,8 @@ Copyright (c) .NET Foundation. All rights reserved.
              to whether there is a PackageId property.
              Also, passing our own PackFolder causes it to be the overriden default for the referenced project. -->
         <AdditionalProperties Condition="'$(_PrivateAssets)' == 'all'">IsPackable=false;PackFolder=$(PackFolder)</AdditionalProperties>
+        <SetPackFolder Condition="'%(PackFolder)' != ''">PackFolder=%(PackFolder)</SetPackFolder>
+        <SetPackFolder Condition="'%(PackFolder)' == '' and '$(_PrivateAssets)' == 'all' and '$(PackFolder)' != ''">PackFolder=$(PackFolder)</SetPackFolder>
       </_NuGetizedProjectReference>
     </ItemGroup>
 


### PR DESCRIPTION
Whenever we had `PrivateAssets=all` on a project reference (whether implicitly or explicitly), we used to unconditionally pass `PackFolder=$(PackFolder)` when resolving referenced content. This is correct whenever the calling project does indeed have a `PackFolder`, but not for packaging projects, since in that case, the packaging project itself doesn't have a value for that property (since it can pack any arbitrary content and has no primary output).

So we switch to the mechanism used already by the .NET SDK (and common targets) of using a metadata item with the full property assignment syntax. This means that if the metadata isn't present (which we now condition to the presence of a value for `PackFolder`), when calling `GetPackageContents` on the project reference, no value will be passed at all for that property, meaning whichever value is there already, will be propagated to the referencing project, which is exactly what we want in a packaging project scenario.

Fixes #139