### PR TITLE
Allow packaging projects to be framework-specific

### DIFF
--- a/src/NuGetizer.Tasks/AssignPackagePath.cs
+++ b/src/NuGetizer.Tasks/AssignPackagePath.cs
@@ -140,8 +140,10 @@ namespace NuGetizer.Tasks
             }
 
             // If the kind is known but it isn't mapped to a folder inside the package, we're done.
-            // Special-case None kind since that means 'leave it wherever it lands' ;)
-            if (string.IsNullOrEmpty(packageFolder) && !packFolder.Equals(PackFolderKind.None, StringComparison.OrdinalIgnoreCase))
+            // Special-case None/Ignore kinds since those means 'leave it wherever it lands' ;)
+            if (string.IsNullOrEmpty(packageFolder) &&
+                !packFolder.Equals(PackFolderKind.None, StringComparison.OrdinalIgnoreCase) &&
+                !packFolder.Equals(PackFolderKind.Ignore, StringComparison.OrdinalIgnoreCase))
                 return output;
 
             // Special case for contentFiles, since they can also provide a codeLanguage metadata

--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.props
@@ -24,6 +24,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
 
     <PackBuildOutput>false</PackBuildOutput>
+    <PackFolder>Ignore</PackFolder>
     <BuildOutputFrameworkSpecific>false</BuildOutputFrameworkSpecific>
   </PropertyGroup>
 

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -119,6 +119,9 @@ Copyright (c) .NET Foundation. All rights reserved.
       <ShouldPack />
       <TargetPath />
     </InferenceCandidate>
+    <_InferredPackageFile>
+      <FrameworkSpecific />
+    </_InferredPackageFile>
   </ItemDefinitionGroup>
 
   <!-- Extend some built-in items with metadata we use in our inference targets -->
@@ -153,21 +156,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <GetPackageContentsDependsOn>
       $(GetPackageContentsDependsOn);
-      _SetBuildOutputFrameworkSpecific;
       _SetDefaultPackageReferencePack;
       InferPackageContents
     </GetPackageContentsDependsOn>
   </PropertyGroup>
-
-  <Target Name="_SetBuildOutputFrameworkSpecific" Condition="'$(BuildOutputFrameworkSpecific)' == ''" Returns="$(BuildOutputFrameworkSpecific)">
-    <!-- Determine whether primary output is framework specific  -->
-    <ItemGroup>
-      <_BuildOutputFrameworkSpecific Include="@(PackFolderKind -> '%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(PackFolder)'" />
-    </ItemGroup>
-    <PropertyGroup>
-      <BuildOutputFrameworkSpecific>@(_BuildOutputFrameworkSpecific)</BuildOutputFrameworkSpecific>
-    </PropertyGroup>
-  </Target>
 
   <Target Name="_SetDefaultPackageReferencePack" Condition="'$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive'"
           BeforeTargets="InferPrimaryOutputDependencies;InferPackageContents">
@@ -212,7 +204,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- Items that are copied to the output directory adopt the kind of the build output -->
         <PackFolder Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != '' or 
                                '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' != 'Never'">$(PackFolder)</PackFolder>
-        <!-- Otherwise they cake on whichever is the default for their item type, as defined by their PackInference item -->
+        <!-- Otherwise they take on whichever is the default for their item type, as defined by their PackInference item -->
         <PackFolder Condition="'%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == '' or 
                                '%(_InferenceCandidateWithTargetPath.CopyToOutputDirectory)' == 'Never'">%(_InferenceCandidateWithTargetPath.DefaultPackFolder)</PackFolder>
       </_InferenceCandidateWithTargetPath>
@@ -261,8 +253,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       </_InferredPackageFile>
 
       <!-- We can't use %(FrameworkFile)==true because it's not defined for raw file references and 
-			     it also includes mscorlib which we don't need
-			     TBD: maybe include ResolvedFrom=ImplicitlyExpandDesignTimeFacades too? -->
+           it also includes mscorlib which we don't need
+           TBD: maybe include ResolvedFrom=ImplicitlyExpandDesignTimeFacades too? -->
       <_InferredPackageFile Include="@(ReferencePath->'%(OriginalItemSpec)')"
                             Condition="'$(PackFrameworkReferences)' == 'true' and 
                                        '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}' and 
@@ -272,16 +264,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <!-- 
-				PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
-				NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
-				current project.
-			-->
+      <!-- PackageId metadata on all PackageFile items means we can tell appart which ones came from which dependencies 
+           NOTE: if PackageId is empty, we won't generate a manifest and it means the files need to be packed with the
+           current project. -->
       <PackageFile Include="@(_InferredPackageFile)">
         <Source>Implicit</Source>
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -84,6 +84,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Default mapping between %(PackageFile.PackageFolder) metadata and package folders inside .nupkg -->
   <ItemGroup>
+    <!-- Used in authoring projects -->
+    <PackFolderKind Include="Ignore" />
     <PackFolderKind Include="Content;ContentFiles">
       <!-- 
         Plain "content" is deprecated as of NuGet v3+

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -9,7 +9,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved. 
 ***********************************************************************************************
 -->
-<Project InitialTargets="_SetPropertiesFromCapabilities" TreatAsLocalProperty="PackFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project InitialTargets="_SetPropertiesFromCapabilities;_SetBuildOutputFrameworkSpecific" TreatAsLocalProperty="PackFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="NuGetizer.Tasks.AssignPackagePath" AssemblyFile="NuGetizer.Tasks.dll" />
   <UsingTask TaskName="NuGetizer.Tasks.WriteItemsToFile" AssemblyFile="NuGetizer.Tasks.dll" />
 
@@ -64,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageFile>
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform Condition="'%(PackageFile.Platform)' == ''">$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'%(PackageFile.TargetFrameworkMoniker)' == '' and '$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker Condition="'%(PackageFile.TargetFrameworkMoniker)' == '' and ('$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true')">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
       </PackageFile>
     </ItemGroup>
 
@@ -167,7 +167,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                                '%(_ReferencedPackageContent.PackFolder)' == 'Metadata'">
         <!-- For consistency, annotate like the rest -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'  or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
         <PackFolder>Dependency</PackFolder>
       </_ReferencedPackageDependency>
       <!-- Remove the referenced package actual contents if it provides a manifest, since it will be a dependency in that case. -->
@@ -184,28 +184,30 @@ Copyright (c) .NET Foundation. All rights reserved.
                                                    OriginalTargetFrameworkMoniker="%(_ReferencedPackageContent.TargetFrameworkMoniker)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(IsPackagingProject)' != 'true'">
-      <!-- Retarget content for the currently building package, if necessary -->
+    <!-- We don't retarget referenced content for packaging projects that aren't framework specific, and
+         never retarget content that already has a PackageId. -->
+    <ItemGroup Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">
       <_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
+        <!-- Assign current package id if appropriate -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
         <!-- Only do this for assets that come from project references that don't build nugets (PackageId=='' above) -->
         <TargetFramework></TargetFramework>
         <!-- NOTE: we're always overwriting the TFM for framework-specific items in this case 
-             since this item will end up making up the contents of this package project in its 
-             current TFM configuration. 
-             TBD: we might want to preserve it anyways and adjust later (i.e. net45 project 
-             references netstandard1.6 project)
-             TODO: take into account cross-targeting.
-				-->
+          since this item will end up making up the contents of this package project in its 
+          current TFM configuration. 
+          TBD: we might want to preserve it anyways and adjust later (i.e. net45 project 
+          references netstandard1.6 project)
+          TODO: take into account cross-targeting.
+		-->
         <TargetFrameworkMoniker Condition="'%(_ReferencedPackageContentWithOriginalValues.FrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
       </_ReferencedPackageContentWithOriginalValues>
     </ItemGroup>
-    
+
     <!-- Otherwise, assign target paths based on the original TFM -->
-    <ItemGroup Condition="'$(IsPackagingProject)' == 'true'">
-      <!-- Retarget content for the currently building package, if necessary -->
+    <ItemGroup Condition="'$(IsPackagingProject)' == 'true' and '$(BuildOutputFrameworkSpecific)' != 'true'">
       <_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
+        <!-- Assign current package id if appropriate -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
         <!-- Only do this for framework-specifc assets that come from project references that don't build nugets (PackageId=='' above) -->
@@ -256,11 +258,12 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- By flagging PrivateAssets=all nugetized references as IsPackable=false, we cause its assets to be 
              packed together with the build output, instead of referenced as a dependency.
              This works because default value for IsPackable checks for '' before defaulting 
-             to whether there is a PackageId property.
-             Also, passing our own PackFolder causes it to be the overriden default for the referenced project. -->
-        <AdditionalProperties Condition="'$(_PrivateAssets)' == 'all'">IsPackable=false;PackFolder=$(PackFolder)</AdditionalProperties>
+             to whether there is a PackageId property. -->
+        <AdditionalProperties Condition="'$(_PrivateAssets)' == 'all'">IsPackable=false;%(_MSBuildProjectReferenceExistent.AdditionalProperties)</AdditionalProperties>
+        <!-- If the project reference itself declares a PackFolder, use that instead of the calling project's -->
         <SetPackFolder Condition="'%(PackFolder)' != ''">PackFolder=%(PackFolder)</SetPackFolder>
-        <SetPackFolder Condition="'%(PackFolder)' == '' and '$(_PrivateAssets)' == 'all' and '$(PackFolder)' != ''">PackFolder=$(PackFolder)</SetPackFolder>
+        <!-- Otherwise, set both PackFolder and BuildOutputFrameworkSpecific so it will match the caller's -->
+        <SetPackFolder Condition="'%(PackFolder)' == '' and '$(_PrivateAssets)' == 'all' and '$(PackFolder)' != '' and '$(PackFolder)' != 'Ignore'">PackFolder=$(PackFolder);BuildOutputFrameworkSpecific=$(BuildOutputFrameworkSpecific)</SetPackFolder>
       </_NuGetizedProjectReference>
     </ItemGroup>
 
@@ -277,6 +280,17 @@ Copyright (c) .NET Foundation. All rights reserved.
         _SplitProjectReferencesByFileExistence;
         _SplitProjectReferencesByIsNuGetized
       </_GetReferencedPackageContentsDependsOn>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_SetBuildOutputFrameworkSpecific" Condition="'$(BuildOutputFrameworkSpecific)' == ''">
+    <!-- Determine whether primary output is framework specific  -->
+    <ItemGroup>
+      <_BuildOutputFrameworkSpecific Include="@(PackFolderKind -> '%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(PackFolder)'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <BuildOutputFrameworkSpecific>@(_BuildOutputFrameworkSpecific)</BuildOutputFrameworkSpecific>
+      <BuildOutputFrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == ''">false</BuildOutputFrameworkSpecific>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGetizer.Tests/AssignPackagePathTests.cs
+++ b/src/NuGetizer.Tests/AssignPackagePathTests.cs
@@ -524,7 +524,7 @@ namespace NuGetizer
         public static IEnumerable<object[]> GetUnmappedKnownKinds => Kinds
             .Where(kind => string.IsNullOrEmpty(kind.GetMetadata(MetadataName.PackageFolder)) &&
                 kind.GetMetadata(MetadataName.PackageFolder) != "contentFiles" &&
-                kind.ItemSpec != PackFolderKind.None)
+                kind.ItemSpec != PackFolderKind.None && kind.ItemSpec != PackFolderKind.Ignore)
             .Select(kind => new object[] { kind.ItemSpec });
 
         [MemberData(nameof(GetUnmappedKnownKinds))]

--- a/src/NuGetizer.Tests/Builder.NuGetizer.cs
+++ b/src/NuGetizer.Tests/Builder.NuGetizer.cs
@@ -183,12 +183,16 @@ static partial class Builder
         {
             if (!BuildResult.ResultsByTarget.ContainsKey(Target))
             {
-                output.WriteLine(this.ToString());
+                output.WriteLine(ToString());
                 Assert.False(true, "Build results do not contain output for target " + Target);
             }
 
             if (ResultCode != TargetResultCode.Success)
-                output.WriteLine(this.ToString());
+            {
+                output.WriteLine(ProjectOrSolutionFile);
+                output.WriteLine("Target: " + Target);
+                output.WriteLine(ToString());
+            }
 
             Assert.Equal(TargetResultCode.Success, ResultCode);
         }

--- a/src/NuGetizer.Tests/Scenarios/given_a_packaging_project/b/b.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_a_packaging_project/b/b.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
   <PropertyGroup>
-		<TargetFramework>net46</TargetFramework>
-		<DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+    <TargetFramework>net46</TargetFramework>
+    <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\d.csproj" />
+  <ItemGroup>
+    <ProjectReference Include="..\d.csproj" />
     <PackageFile Include="@(None)" PackagePath="docs\%(RelativeDir)%(Filename)%(Extension)" />
     <PackageFile Include="as-is.txt" PackFolder="None" IsFile="false" Condition="'$(AddAsIs)' == 'true'" />
   </ItemGroup>

--- a/src/NuGetizer.Tests/given_projectreferences.cs
+++ b/src/NuGetizer.Tests/given_projectreferences.cs
@@ -169,7 +169,7 @@ namespace NuGetizer
         }
 
         [Fact]
-        public void when_build_kind_then_does_not_pack_msbuild()
+        public void when_build_pack_folder_then_does_not_pack_msbuild()
         {
             var result = Builder.BuildProject(@"
 <Project Sdk='Microsoft.NET.Sdk'>
@@ -193,7 +193,7 @@ namespace NuGetizer
         }
 
         [Fact]
-        public void when_build_kind_and_explicit_pack_then_packs_msbuild()
+        public void when_build_pack_folder_and_explicit_pack_then_packs_msbuild()
         {
             var result = Builder.BuildProject(@"
 <Project Sdk='Microsoft.NET.Sdk'>
@@ -215,68 +215,5 @@ namespace NuGetizer
                 PackFolder = PackFolderKind.Dependency,
             }));
         }
-
-        [Fact]
-        public void when_projectreference_explicit_packfolder_then_specific_folder_is_packed()
-        {
-            var result = Builder.BuildProject(@"
-<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
-  <PropertyGroup>
-    <PackageId>Packer</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include='Library.csproj' AdditionalProperties='PackFolder=lib/net6.0/SpecificFolder' />
-  </ItemGroup>
-</Project>",
-                "GetPackageContents", output,
-                files: ("Library.csproj", @"
-<Project Sdk='Microsoft.NET.Sdk'>
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include='Microsoft.NETFramework.ReferenceAssemblies' Version='1.0.2' />
-  </ItemGroup>
-</Project>"));
-
-            result.AssertSuccess(output);
-            Assert.Contains(result.Items, item => item.Matches(new
-            {
-                PackagePath = @"lib/net6.0/SpecificFolder/Library.dll",
-            }));
-        }
-
-        [Fact]
-        public void when_projectreference_has_packfolder_metadata_then_specific_folder_is_packed()
-        {
-            var result = Builder.BuildProject(@"
-<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
-  <PropertyGroup>
-    <PackageId>Packer</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include='Library.csproj' PackFolder='lib/net6.0/SpecificFolder' />
-  </ItemGroup>
-</Project>",
-                "GetPackageContents", output,
-                files: ("Library.csproj", @"
-<Project Sdk='Microsoft.NET.Sdk'>
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include='Microsoft.NETFramework.ReferenceAssemblies' Version='1.0.2' />
-  </ItemGroup>
-</Project>"));
-
-            result.AssertSuccess(output);
-            Assert.Contains(result.Items, item => item.Matches(new
-            {
-                PackagePath = @"lib/net6.0/SpecificFolder/Library.dll",
-            }));
-        }
-
     }
 }


### PR DESCRIPTION
We refine the support for packaging projects in this commit, by defaulting its PackFolder to Ignore, which becomes somewhat similar to None, but allows for differenciation.

Moreover, we test specific scenarios involving a packaging project becoming framework-specific (which we previously didn't explicitly support) by means of setting `BuildOutputFrameworkSpecific=true` at the project level. This requires re-targeting referenced assets whenever that property is true, in addition to non-packaging projects in that same scenario.

Fixes #182