### PR TITLE
Improve default heuristics for build projects

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.Defaults.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.NoTargets.Defaults.targets
@@ -1,6 +1,6 @@
 ﻿<!--
 ***********************************************************************************************
-NuGetizer.Authoring.NoTargets.props
+NuGetizer.Authoring.NoTargets.Defaults.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -11,12 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CustomAfterNoTargets>$(MSBuildThisFileDirectory)NuGetizer.Authoring.NoTargets.targets</CustomAfterNoTargets>
-    
-    <!-- If the NoTargets project happens to be named .csproj or .vbproj, we'd need to re-set the DefaultLanguageSourceExtension -->
-    <CustomAfterMicrosoftCSharpTargets>$(MSBuildThisFileDirectory)NuGetizer.Authoring.NoTargets.Defaults.targets</CustomAfterMicrosoftCSharpTargets>
-    <CustomAfterMicrosoftVisualBasicTargets>$(MSBuildThisFileDirectory)NuGetizer.Authoring.NoTargets.Defaults.targets</CustomAfterMicrosoftVisualBasicTargets>
-
     <!-- This enables the default items inference to work properly for Content/None items -->
     <DefaultLanguageSourceExtension>.__</DefaultLanguageSourceExtension>
   </PropertyGroup>

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -28,7 +28,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(PackDependencies)' == 'false'">false</PackFrameworkReferences>
     <!-- Only default to true if the project isn't a nuget packaging project itself and its primary output is lib. -->
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IsPackagingProject)' != 'true' and '$(PackFolder)' == 'lib'">true</PackFrameworkReferences>
-
+    <!-- When PackFolder is build/buildTransitive, we default to packing None since it's most intuitive in that case -->
+    <PackNone Condition="'$(PackNone)' == '' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive')">true</PackNone>
+    
     <_OutputFullPath Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</_OutputFullPath>
     <_OutputFullPath Condition="'$(_OutputFullPath)' == ''">$(MSBuildProjectDirectory.TrimEnd('\'))\$(OutputPath)</_OutputFullPath>
   </PropertyGroup>
@@ -173,7 +175,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CollectInferenceCandidates" Inputs="@(PackInference)" Outputs="%(PackInference.Identity)-BATCH">
     <PropertyGroup>
       <PackExclude>%(PackInference.PackExclude)</PackExclude>
+      <PackInferenceIdentity>%(PackInference.Identity)</PackInferenceIdentity>
     </PropertyGroup>
+
+    <ItemGroup Condition="'$(PackInferenceIdentity)' == 'None' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive')">
+      <None Update="@(None)" Condition="'%(None.PackFolder)' == ''" PackFolder="$(PackFolder)" />
+      <None Update="@(None)" Condition="'%(None.FrameworkSpecific)' == ''" FrameworkSpecific="$(BuildFrameworkSpecific)" />
+    </ItemGroup>
+    
     <!-- If we have an exclude wildcard to evaluate, do so and keep only non-matching items -->
     <EvaluateWildcards Condition="'$(PackExclude)' != ''" Items="@(%(PackInference.Identity))" Wildcards="$(PackExclude)">
       <Output TaskParameter="NonMatchingItems" ItemName="InferenceCandidate" />

--- a/src/NuGetizer.Tests/Builder.NuGetizer.cs
+++ b/src/NuGetizer.Tests/Builder.NuGetizer.cs
@@ -27,11 +27,17 @@ static partial class Builder
         LoggerVerbosity? verbosity = null,
         params (string name, string contents)[] files)
     {
+        var projectFile = projectContent.Contains("Microsoft.Build.NoTargets") ?
+            "scenario.msbuildproj" : "scenario.csproj";
+
         return BuildProjects(
             target: target,
             output: output,
             verbosity: verbosity,
-            files: new[] { ("scenario.csproj", projectContent) }.Concat(files).ToArray());
+            files: new[]
+            {
+                (projectFile, projectContent)
+            }.Concat(files).ToArray());
     }
 
     public static TargetResult BuildProjects(

--- a/src/NuGetizer.Tests/given_a_packaging_project.cs
+++ b/src/NuGetizer.Tests/given_a_packaging_project.cs
@@ -319,5 +319,27 @@ namespace NuGetizer
                 PackagePath = @"tools/net6.0/Library.dll",
             }));
         }
+
+        [Fact]
+        public void when_pack_folder_build_then_none_packs_as_build()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net6.0</TargetFramework>
+    <PackFolder>build</PackFolder>
+    <EnableDefaultItems>true</EnableDefaultItems>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("Packer.targets", @"<Project />"));
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"build/Packer.targets",
+            }));
+        }
     }
 }


### PR DESCRIPTION
Make it so that the default behavior for None items when the PackFolder for the project is build or buildTransitive the None matches the project. This is unless the item doesn't specify a different FrameworkSpecific or PackFolder metadata.

This fixes the default items that were not being properly populated for packaging projects too, due to the lack of a default file extension (meaning all default items end up being ignored).

Fixes #184.