### PR TITLE
Improve readme content inclusion metadata inference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,14 @@ don't have to customize the project much and can instead let the rules build up 
 of your package by interpreting your existing project elements. It works by transforming various built-in 
 items into corresponding `PackageFile` items, much as if you had added them by hand.
 
+For example, if you create a `readme.md` file alongside the project, it will (by default) be 
+automatically included in the package and set as the `Readme` metadata. Likewise, if you provide 
+the `$(PackageReadmeFile)` property pointing to a different filename (say, `readme.txt`), it will 
+also be automatically added to the package, without you having to add an explicit `PackageFile` or 
+update the item with `<None Update='readme.txt' Pack='true' />` so it packs properly. 
+
+> NOTE: package readme inference can be turned off with the `PackReadme=false` project property.
+
 Inference can be turned off for specific items by just adding `Pack="false"` 
 item metadata. It can also be turned off by default for all items of a given type with an item definition group:
 
@@ -159,6 +167,7 @@ Whether items are packed by default or not is controlled by properties named aft
 | Property        | Default Value |
 |-----------------|---------------|
 | PackBuildOutput | true |
+| PackReadme      | true |
 | PackSymbols     | true if PackBuildOutput=true (*) |
 | PackDependencies| empty (**) |
 | PackFrameworkReferences | true if PackFolder=lib, false if PackDependencies=false |

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -17,6 +17,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The PackFolder of primary output (build, symbols, doc and satellite assemblies) set if PackBuildOutput = true -->
     <PackFolder Condition="'$(PackFolder)' == ''">lib</PackFolder>
 
+    <!-- Whether to automatically include a None item named `readme.md` -->
+    <PackReadme Condition="'$(PackReadme)' == ''">true</PackReadme>
+
     <!-- Whether to include @(Content) items with CopyToOutputDirectory != '' in the package -->
     <PackContent Condition="'$(PackContent)' == ''">true</PackContent>
     <!-- Whether to include @(BuiltProjectOutputGroupOutput), @(DocumentationProjectOutputGroupOutput) and @(SatelliteDllsProjectOutputGroupOutput) items in the package -->
@@ -30,9 +33,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IsPackagingProject)' != 'true' and '$(PackFolder)' == 'lib'">true</PackFrameworkReferences>
     <!-- When PackFolder is build/buildTransitive, we default to packing None since it's most intuitive in that case -->
     <PackNone Condition="'$(PackNone)' == '' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive')">true</PackNone>
-    
+
     <_OutputFullPath Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</_OutputFullPath>
     <_OutputFullPath Condition="'$(_OutputFullPath)' == ''">$(MSBuildProjectDirectory.TrimEnd('\'))\$(OutputPath)</_OutputFullPath>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package Readme" Condition="'$(PackReadme)' == 'true' and '$(IsPackable)' == 'true'">
+    <PackageReadmeFilename>readme</PackageReadmeFilename>
+    <PackageReadmeExtension>.md</PackageReadmeExtension>
+
+    <PackageReadmeFilename Condition="'$(PackageReadmeFile)' != ''">$([System.IO.Path]::GetFilenameWithoutExtension('$(PackageReadmeFile)'))</PackageReadmeFilename>
+    <PackageReadmeExtension Condition="'$(PackageReadmeFile)' != ''">$([System.IO.Path]::GetExtension('$(PackageReadmeFile)'))</PackageReadmeExtension>
+
+    <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' and Exists('$(MSBuildProjectDirectory)\$(PackageReadmeFilename)$(PackageReadmeExtension)')">$(PackageReadmeFilename)$(PackageReadmeExtension)</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemDefinitionGroup Label="Inference Defaults">
@@ -182,7 +195,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <None Update="@(None)" Condition="'%(None.PackFolder)' == ''" PackFolder="$(PackFolder)" />
       <None Update="@(None)" Condition="'%(None.FrameworkSpecific)' == ''" FrameworkSpecific="$(BuildFrameworkSpecific)" />
     </ItemGroup>
-    
+
     <!-- If we have an exclude wildcard to evaluate, do so and keep only non-matching items -->
     <EvaluateWildcards Condition="'$(PackExclude)' != ''" Items="@(%(PackInference.Identity))" Wildcards="$(PackExclude)">
       <Output TaskParameter="NonMatchingItems" ItemName="InferenceCandidate" />
@@ -194,6 +207,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="InferPackageContents" DependsOnTargets="$(InferPackageContentsDependsOn);_CollectInferenceCandidates" Returns="@(PackageFile)">
+
+    <!-- Even if all these conditions are false, the user can still explicitly pack the file, of course -->
+    <ItemGroup Label="Readme" Condition="'$(PackReadme)' == 'true' and '$(PackageReadmeFile)' != '' and '$(IsPackable)' == 'true'">
+      <InferenceCandidate Include="@(None -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))"
+                          PackagePath="%(Filename)%(Extension)"
+                          Condition="'%(Extension)' == '$(PackageReadmeExtension)'" />
+    </ItemGroup>
+
     <ItemGroup>
       <InferenceCandidate>
         <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(PackFolder)' != '' or '%(PackageReference)' != '') and '%(Pack)' != 'false'">true</ShouldPack>

--- a/src/NuGetizer.Tests/NuGetizer.Tests.csproj
+++ b/src/NuGetizer.Tests/NuGetizer.Tests.csproj
@@ -25,10 +25,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly" Version="1.0.9" PrivateAssets="all" />
   </ItemGroup>
   

--- a/src/NuGetizer.Tests/given_a_packaging_project.cs
+++ b/src/NuGetizer.Tests/given_a_packaging_project.cs
@@ -329,6 +329,7 @@ namespace NuGetizer
     <PackageId>Packer</PackageId>
     <TargetFramework>net6.0</TargetFramework>
     <PackFolder>build</PackFolder>
+    <!-- Only needed since for scenarios we set this to false. -->
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
 </Project>",
@@ -339,6 +340,132 @@ namespace NuGetizer
             Assert.Contains(result.Items, item => item.Matches(new
             {
                 PackagePath = @"build/Packer.targets",
+            }));
+        }
+
+        [Fact]
+        public void when_readme_found_but_pack_readme_false_then_does_not_add_it()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Only needed since for scenarios we set this to false. -->
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <PackReadme>false</PackReadme>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("readme.md", @"# readme"));
+
+            result.AssertSuccess(output);
+
+            // Assert the readme file is not added to the package
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"readme.md",
+            }));
+
+            // Assert the package metadata is not present
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Packer",
+                Readme = "readme.md",
+            }));
+        }
+
+        [Fact]
+        public void when_readme_found_but_project_not_packable_then_does_not_add_content()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Only needed since for scenarios we set this to false. -->
+    <EnableDefaultItems>true</EnableDefaultItems>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("readme.md", @"# readme"));
+
+            result.AssertSuccess(output);
+
+            // Assert the readme file is not added to the package
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"readme.md",
+            }));
+
+            // Assert the package metadata is not present
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                Identity = "Packer",
+                Readme = "readme.md",
+            }));
+        }
+
+        [Fact]
+        public void when_readme_found_then_adds_metadata_and_content()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Only needed since for scenarios we set this to false. -->
+    <EnableDefaultItems>true</EnableDefaultItems>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("readme.md", @"# readme"));
+
+            result.AssertSuccess(output);
+
+            // Assert the readme file is added to the package
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"readme.md",
+            }));
+
+            // Assert the package metadata is present too
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Packer",
+                Readme = "readme.md",
+            }));
+        }
+
+        [Fact]
+        public void when_readme_custom_extension_specified_then_adds_metadata_and_content()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.Build.NoTargets/3.5.0'>
+  <PropertyGroup>
+    <PackageId>Packer</PackageId>
+    <TargetFramework>net6.0</TargetFramework>
+    <!-- Only needed since for scenarios we set this to false. -->
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <PackageReadmeFile>readme.txt</PackageReadmeFile>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output,
+                files: ("readme.txt", @"readme"));
+
+            result.AssertSuccess(output);
+
+            // Assert the readme file is added to the package
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = @"readme.txt",
+            }));
+
+            // Assert the package metadata is present too
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Packer",
+                Readme = "readme.txt",
             }));
         }
     }


### PR DESCRIPTION
A readme.md file at the project level will typically be automatically included as a None item,
which by default won't pack either.

This improves the inference by adding a `PackReadme=true` (by default) which controls whether a readme file (either explicitly specified with `PackageReadmeFile` as per the SDK Pack spec, or implicitly found alongside the project) is automatically packed and set as the Readme package metadata (as long as the project is being packed (IsPackable=true)).

NOTE: this is implemented in the Inference targets, so that when inference is turned off entirely,
this doesn't happen automatically, for consistency with other items inferences.

Fixes #185