### PR TITLE
Support transitive package dependency from P2P

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -194,13 +194,16 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- Only do this for assets that come from project references that don't build nugets (PackageId=='' above) -->
         <TargetFramework></TargetFramework>
         <!-- NOTE: we're always overwriting the TFM for framework-specific items in this case 
-          since this item will end up making up the contents of this package project in its 
+          since this item will end up making up the contents of this project package in its 
           current TFM configuration. 
           TBD: we might want to preserve it anyways and adjust later (i.e. net45 project 
           references netstandard1.6 project)
           TODO: take into account cross-targeting.
 		-->
         <TargetFrameworkMoniker Condition="'%(_ReferencedPackageContentWithOriginalValues.FrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <!-- Transitive dependencies from non-packing projects should be lifted as direct dependencies of the packing project, 
+             using its TFM, since they would need to become dependencies of the packing project in the current TFM. -->
+        <TargetFrameworkMoniker Condition="'%(_ReferencedPackageContentWithOriginalValues.PackFolder)' == 'Dependency'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
       </_ReferencedPackageContentWithOriginalValues>
     </ItemGroup>
 

--- a/src/NuGetizer.Tests/NuGetizer.Tests.csproj
+++ b/src/NuGetizer.Tests/NuGetizer.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);Scenarios\**\*</DefaultItemExcludes>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
We were previously not re-targeting dependencies from referenced (non-packing) projects, which would end up as dependencies in the originating project TFM, instead of the packing (TFM-specific) project, causing a runtime failure since the dependency wouldn't be present, even if the referenced assembly would.

This is now supported, including in multi-targeting scenarios for the packing project.

Fixes #199