### PR TITLE
Latest agents with .net48 fail to run tests due to missing method

### DIFF
--- a/src/NuGetizer.Tests/NuGetizer.Tests.csproj
+++ b/src/NuGetizer.Tests/NuGetizer.Tests.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.2.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build" Version="17.3.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.3.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.3" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.669" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />


### PR DESCRIPTION
The root cause analysis was performed in https://github.com/dotnet/msbuild/issues/7873.

By upgrading to latest MSBuild 17.3.1, the issue is resolved.