### PR TITLE
Generate and upload binlogs, don't version test build/run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,28 @@ jobs:
         shell: pwsh
         working-directory: src/NuGetizer.Tests
         run: |
-          msbuild -r -m:1
           dotnet restore Scenarios/given_a_packaging_project/a.nuproj
+          msbuild -r
+
+      - name: 📦 binlog
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: binlog-build-${{ github.run_number }}
+          path: src/NuGetizer.Tests/msbuild.binlog
 
       - name: 🧪 test
         uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
+
+      - name: 📦 binlog
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: binlog-pack-${{ github.run_number }}
+          path: msbuild.binlog
 
       # Only push CI package to sleet feed if building on ubuntu (fastest)
       - name: 🚀 sleet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,14 +32,28 @@ jobs:
         shell: pwsh
         working-directory: src/NuGetizer.Tests
         run: |
-          msbuild -r -m:1 -p:version=${GITHUB_REF#refs/*/v}
           dotnet restore Scenarios/given_a_packaging_project/a.nuproj
+          msbuild -r
+
+      - name: 📦 binlog
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: binlog-build-${{ github.run_number }}
+          path: src/NuGetizer.Tests/msbuild.binlog
 
       - name: 🧪 test
         uses: ./.github/workflows/test
 
       - name: 📦 pack
-        run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}
+        run: dotnet pack -p:version=${GITHUB_REF#refs/*/v}
+
+      - name: 📦 binlog
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: binlog-pack-${{ github.run_number }}
+          path: msbuild.binlog
 
       - name: 🚀 nuget
         run: dotnet nuget push ./bin/**/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,4 +1,5 @@
 # See https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files
+-bl
 -nr:false
 -m:1
 -v:m


### PR DESCRIPTION
Since the test build/run step is run in pwsh, the expression
to set the version isn't working, but we don't need that anyway,
since `pack` will already pass the right version and will end
up causing a new build.