### PR TITLE
When include in readme fails, log a warning

### DIFF
--- a/src/NuGetizer.Tasks/CreatePackage.cs
+++ b/src/NuGetizer.Tasks/CreatePackage.cs
@@ -203,8 +203,9 @@ namespace NuGetizer.Tasks
                 File.Exists(readmeFile.Source))
             {
                 // replace readme with includes replaced.
+                var replaced = IncludesResolver.Process(readmeFile.Source, message => Log.LogWarningCode("NG001", message));
                 var temp = Path.GetTempFileName();
-                File.WriteAllText(temp, IncludesResolver.Process(readmeFile.Source));
+                File.WriteAllText(temp, replaced);
                 readmeFile.Source = temp;
             }
 

--- a/src/NuGetizer.Tasks/IncludesResolver.cs
+++ b/src/NuGetizer.Tasks/IncludesResolver.cs
@@ -13,7 +13,7 @@ public class IncludesResolver
     static readonly Regex IncludeRegex = new Regex(@"<!--\s?include\s(.*?)\s?-->", RegexOptions.Compiled);
     static readonly HttpClient http = new();
 
-    public static string Process(string filePath)
+    public static string Process(string filePath, Action<string> logWarning = default)
     {
         string content = null;
 
@@ -74,8 +74,10 @@ public class IncludesResolver
                     var anchor = $"<!-- {fragment} -->";
                     var start = includedContent.IndexOf(anchor);
                     if (start == -1)
-                        // Warn/error?
+                    {
+                        logWarning?.Invoke($"Failed to resolve anchor {fragment} in {includedPath}.");
                         continue;
+                    }
 
                     includedContent = includedContent.Substring(start);
                     var end = includedContent.IndexOf(anchor, anchor.Length);
@@ -90,6 +92,10 @@ public class IncludesResolver
                     replacements[existingRegex] = replacement;
                 else
                     replacements[new Regex(@$"<!--\s?include {includedPath}{fragment}\s?-->")] = replacement;
+            }
+            else
+            {
+                logWarning?.Invoke($"Failed to resolve include: {includedPath}{fragment}. File not found at expected location {includedFullPath}.");
             }
         }
 

--- a/src/NuGetizer.Tests/IncludesResolverTests.cs
+++ b/src/NuGetizer.Tests/IncludesResolverTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.IO;
+using Xunit;
 
 namespace NuGetizer;
 
@@ -24,5 +25,19 @@ public class IncludesResolverTests
         var content = IncludesResolver.Process("Content/url.md");
 
         Assert.Contains("Daniel Cazzulino", content);
+    }
+
+    [Fact]
+    public void ResolveNonExistingInclude()
+    {
+        var path = Path.GetTempFileName();
+        var include = "<!-- include foo.md#bar -->";
+        File.WriteAllText(path, include);
+
+        string? failed = default;
+        var content = IncludesResolver.Process(path, s => failed = s);
+
+        Assert.NotNull(failed);
+        Assert.Contains("foo.md#bar", failed);
     }
 }


### PR DESCRIPTION
This makes it easier to troubleshoot include authoring mistakes.

Fixes #232