### PR TITLE
Don't fail nugetize for tools

### DIFF
--- a/src/dotnet-nugetize/Program.cs
+++ b/src/dotnet-nugetize/Program.cs
@@ -78,7 +78,8 @@ namespace NuGetize
                 "-p:SkipCompilerExecution=true",
                 "-p:DesignTimeBuild=true",
                 "-p:DesignTimeSilentResolution=true",
-                "-p:ResolveAssemblyReferencesSilent=true"
+                "-p:ResolveAssemblyReferencesSilent=true",
+                "-p:IsPublishable=false"
             });
 
             if (help)


### PR DESCRIPTION
For dotnet tool projects, the design-time build we performed failed since the tool attempted to publish its output, which the project references weren't able to supply and the whole thing failed with missing files.

We now pass IsPublishable=false to fake a sort of "DTB" for tools too, so they don't attempt to publish output.

Fixes #247