### PR TITLE
Make IsDevelopmentDependency legacy

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
@@ -43,6 +43,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackSymbols Condition="'$(PackSymbols)' == '' and '$(IncludeSymbolsInPackage)' != ''">$(IncludeSymbolsInPackage)</PackSymbols>
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IncludeFrameworkReferencesInPackage)' != ''">$(IncludeFrameworkReferencesInPackage)</PackFrameworkReferences>
     <PackProjectReferences Condition="'$(PackProjectReferences)' == '' and '$(PackProjectReference)' != ''">true</PackProjectReferences>
+
+    <DevelopmentDependency Condition="'$(IsDevelopmentDependency)' != ''">$(IsDevelopmentDependency)</DevelopmentDependency>
   </PropertyGroup>
 
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
@@ -55,7 +55,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemDefinitionGroup>
     <PackageMetadata>
       <PackageId>$(PackageId)</PackageId>
-      <DevelopmentDependency Condition="'$(IsDevelopmentDependency)' == 'true'">true</DevelopmentDependency>
+      <DevelopmentDependency>$(DevelopmentDependency)</DevelopmentDependency>
 
       <Authors Condition="'$(Authors)' != ''">$(Authors)</Authors>
       <Owners Condition="'$(Owners)' != ''">$(Owners)</Owners>

--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -128,7 +128,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- By not re-creating the item, we preserve whatever metadata was provided already -->
       <PackageMetadata Include="$(PackageId)" Condition="'@(PackageMetadata)' == ''">
         <PackageId>$(PackageId)</PackageId>
-        <DevelopmentDependency Condition="'$(IsDevelopmentDependency)' == 'true'">true</DevelopmentDependency>
+        <DevelopmentDependency Condition="'$(DevelopmentDependency)' == 'true'">true</DevelopmentDependency>
         <Authors Condition="'$(Authors)' != ''">$(Authors)</Authors>
         <Owners Condition="'$(Owners)' != ''">$(Owners)</Owners>
         <Title Condition="'$(Title)' != ''">$(Title)</Title>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
@@ -18,7 +18,7 @@
     <Title>NuGetizer</Title>
     <Description>Simple, flexible and powerful NuGet packaging</Description>
 
-    <IsDevelopmentDependency>true</IsDevelopmentDependency>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <PackFolder>build</PackFolder>
 
     <PackOnBuild Condition="'$(PackOnBuild)' == '' And '$(Configuration)' == 'Release'">true</PackOnBuild>

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -33,6 +33,26 @@ namespace NuGetizer
         }
 
         [Fact]
+        public void when_development_dependency_then_package_has_development_dependency_metadata()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+</Project>", output: output);
+
+            result.AssertSuccess(output);
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackFolder = PackFolderKind.Metadata,
+                DevelopmentDependency = "true"
+            }));
+        }
+
+        [Fact]
         public void when_is_packable_true_but_packageid_reset_to_empty_then_fails()
         {
             var result = Builder.BuildProject(@"


### PR DESCRIPTION
We should support the OOb SDK Pack property instead. In this case, it's intuitive enough and will likely get completion support eventually, as well as docs.

See https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference

Fixes #253