### PR TITLE
Add NuGetPackageId metadata to target path item

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -63,6 +63,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <TargetPathWithTargetPlatformMoniker>
       <IsPackable>$(IsPackable)</IsPackable>
       <IsNuGetized>true</IsNuGetized>
+      <!-- Allows P2P references to inspect this information, which will always be available when referencing the package -->
+      <NuGetPackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</NuGetPackageId>
     </TargetPathWithTargetPlatformMoniker>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
This allows P2P references to inspect this value in a standard way that is consistent with package references.

Resolved assets via NuGet always contain this item metadata, so it makes sense to add it to a referenced project's output for consistency. In the case of analyzers, this could be helpful in filering analyzers by their package id in both cases in a uniform way.