### PR TITLE
PackageFile should be hidden from solution explorer

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -65,6 +65,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageReferencePath />
       <!-- Populated by content inference to preserve original identity -->
       <OriginalItemSpec />
+      <!-- Don't show package files in project explorer by default -->
+      <Visible>false</Visible>
     </PackageFile>
     <PackageReference>
       <!-- See https://github.com/NuGet/Home/wiki/PackageReference-Specification -->


### PR DESCRIPTION
By default, it should not appear, since otherwise it seems like something's broken when it's not. PackageFiles can reference arbitrary things that are not necessarily physical files so they can show up as broken file references.

Should improve the experience for cases like https://github.com/devlooped/nugetizer/issues/263#issuecomment-1418958506