### PR TITLE
Pack runtime lib assets when inferring dependencies

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -154,6 +154,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Pack Condition="'$(PackDependencies)' == 'false'">false</Pack>
       <PrivateAssets />
     </ImplicitPackageReference>
+    <ReferenceCopyLocalPathsOutputGroupOutput>
+      <Facade>false</Facade>
+      <FrameworkFile>false</FrameworkFile>
+      <NuGetPackageId />
+      <Pack />
+    </ReferenceCopyLocalPathsOutputGroupOutput>
     <ReferencePath>
       <Facade>false</Facade>
       <FrameworkFile>false</FrameworkFile>
@@ -373,11 +379,20 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="_CollectPrimaryOutputDependencies" DependsOnTargets="BuildOnlySettings;RunResolvePackageDependencies;ResolveReferences" Returns="@(ImplicitPackageReference)">
+  <Target Name="_CollectPrimaryOutputDependencies" DependsOnTargets="ReferenceCopyLocalPathsOutputGroup;RunResolvePackageDependencies" Returns="@(ImplicitPackageReference)">
     <Error Code="NG1003" Text="Centrally managed package versions is only supported when using the Microsoft.NET.Sdk."
            Condition="'$(ManagePackageVersionsCentrally)' == 'true' and '$(UsingMicrosoftNETSdk)' != 'true'" />
     <ItemGroup>
-      <_PrimaryOutputRelatedFile Include="@(ReferencePath);@(_ReferenceRelatedPaths)"
+      <!-- By adding the files in this order, we ensure that Distinct() will preserve this preference order.
+				   We add them with identities that will find the duplicate files resolved from the same package id, 
+				   so we can de-duplicate using the given preference order. -->
+      <_CopyLocalReference Include="@(ReferenceCopyLocalPathsOutputGroupOutput->'%(NuGetPackageId)|%(Filename)%(Extension)')" OriginalItemSpec="%(Identity)" />
+      <_CopyLocalReference Include="@(ReferencePath->'%(NuGetPackageId)|%(Filename)%(Extension)')" OriginalItemSpec="%(Identity)" />
+      <_CopyLocalReference Include="@(_ReferenceRelatedPaths->'%(NuGetPackageId)|%(Filename)%(Extension)')" OriginalItemSpec="%(Identity)" />
+      <_CopyLocalReferenceDistinct Include="@(_CopyLocalReference->Distinct())" />
+      <_ReferenceCopyLocalPaths Include="@(_CopyLocalReferenceDistinct->'%(OriginalItemSpec)')" />
+
+      <_PrimaryOutputRelatedFile Include="@(_ReferenceCopyLocalPaths)"
                                  Condition="'%(NuGetPackageId)' != 'NETStandard.Library' and 
                                             '%(Facade)' != 'true' and 
                                             '%(FrameworkFile)' != 'true' and 

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -714,5 +714,38 @@ namespace NuGetizer
                 TargetFramework = "netstandard2.0",
             }));
         }
+
+        [Fact]
+        public void when_packing_with_refs_then_includes_runtime_libs_for_private()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                	<PropertyGroup>
+                		<OutputType>Exe</OutputType>
+                		<TargetFramework>net472</TargetFramework>
+                		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+                		<PackageId>TestNuGetizer</PackageId>
+                		<LangVersion>Latest</LangVersion>
+                	</PropertyGroup>
+
+                	<ItemGroup>
+                		<PackageReference Include="System.Buffers" Version="4.5.1" PrivateAssets="all" />
+                		<PackageReference Include="System.Memory" Version="4.5.5" PrivateAssets="all" />
+                	</ItemGroup>
+                </Project>
+                """, output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PathInPackage = "lib/net461/System.Buffers.dll",
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PathInPackage = "lib/net461/System.Memory.dll",
+            }));
+        }
     }
 }

--- a/src/NuGetizer.Tests/NuGetizer.Tests.csproj
+++ b/src/NuGetizer.Tests/NuGetizer.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);Scenarios\**\*</DefaultItemExcludes>
-    <LangVersion>Preview</LangVersion>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/NuGetizer.Tests/given_a_library_with_private_assets_reference.cs
+++ b/src/NuGetizer.Tests/given_a_library_with_private_assets_reference.cs
@@ -29,7 +29,6 @@ namespace NuGetizer
             {
                 PackFolder = PackFolderKind.Lib,
                 Filename = "Mono.Options",
-                NuGetSourceType = "Package",
                 NuGetPackageId = "Mono.Options",
             }));
         }
@@ -53,7 +52,6 @@ namespace NuGetizer
             {
                 PackFolder = PackFolderKind.Lib,
                 Filename = "Newtonsoft.Json",
-                NuGetSourceType = "Package",
                 NuGetPackageId = "Newtonsoft.Json",
             }));
         }
@@ -77,7 +75,6 @@ namespace NuGetizer
             {
                 PackFolder = PackFolderKind.Lib,
                 Filename = "xunit",
-                NuGetSourceType = "Package",
                 NuGetPackageId = "xunit",
             }));
         }


### PR DESCRIPTION
We were previously using a combination of @(ReferencePath) and @(_ReferenceRelatedPaths) to determine the candidate libs to pack as private, but this was incorrect since we would still sometimes pack ref assemblies.

Turns out that this is an issue that surfaced elsewhere (see https://github.com/NuGet/Home/issues/9310#issuecomment-612307251) which resulted in a new output group being available from the common MSBuild targets (see https://github.com/dotnet/msbuild/issues/3069) that we can use instead to do this properly.

Closes #263