### PR TITLE
Reduce dependency surface on ThisAssembly, remove older local stuff

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -13,7 +13,6 @@
 
     <!-- Ignore warning for: Package 'NuGet.ProjectManagement 4.2.0' was restored using '.NETFramework,Version=v4.6.1, -->
     <NoWarn>NU1701</NoWarn>
-    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin'));$(RestoreSources)</RestoreSources>
   </PropertyGroup>
 
   <Target Name="Pack" />

--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -13,8 +13,4 @@
     <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">
-    <PackageReference Update="ThisAssembly" Version="1.0.9" />
-  </ItemGroup>
-
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
@@ -12,7 +12,8 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="6.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.ProjectManagement" Version="4.2.0" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly" Version="1.0.10" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="1.0.10" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Strings" Version="1.0.10" PrivateAssets="all" />
     <PackageReference Include="Minimatch" Version="2.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/dotnet-nugetize/dotnet-nugetize.csproj
+++ b/src/dotnet-nugetize/dotnet-nugetize.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly" Version="1.0.10" />
+    <PackageReference Include="ThisAssembly.Project" Version="1.0.10" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We don't need ALL of the ThisAssembly generators, just the ones we use