### PR TITLE
Support Include/Exclude attributes from Dependency

### DIFF
--- a/src/NuGetizer.Tasks/CreatePackage.cs
+++ b/src/NuGetizer.Tasks/CreatePackage.cs
@@ -42,7 +42,8 @@ namespace NuGetizer.Tasks
 
         public override bool Execute()
         {
-            if (Environment.GetEnvironmentVariable("DEBUG_NUGETIZER") == "1")
+            if (Environment.GetEnvironmentVariable("DEBUG_NUGETIZER") == "1" ||
+                Environment.GetEnvironmentVariable("DEBUG_NUGETIZER_PACK") == "1")
                 Debugger.Launch();
 
             try
@@ -244,8 +245,8 @@ namespace NuGetizer.Tasks
                                    Id = item.ItemSpec,
                                    Version = VersionRange.Parse(item.GetMetadata(MetadataName.Version)),
                                    TargetFramework = item.GetNuGetTargetFramework(),
-                                   Include = item.GetNullableMetadata(MetadataName.IncludeAssets),
-                                   Exclude = item.GetNullableMetadata(MetadataName.ExcludeAssets)
+                                   Include = item.GetNullableMetadata(MetadataName.PackInclude) ?? item.GetNullableMetadata(MetadataName.IncludeAssets),
+                                   Exclude = item.GetNullableMetadata(MetadataName.PackExclude) ?? item.GetNullableMetadata(MetadataName.ExcludeAssets)
                                };
 
             var definedDependencyGroups = (from dependency in dependencies

--- a/src/NuGetizer.Tasks/MetadataName.cs
+++ b/src/NuGetizer.Tasks/MetadataName.cs
@@ -30,9 +30,27 @@
         /// </summary>
         public const string PrivateAssets = nameof(PrivateAssets);
 
+        /// <summary>
+        /// Assets to include for a dependency/package reference
+        /// </summary>
         public const string IncludeAssets = nameof(IncludeAssets);
 
+        /// <summary>
+        /// Assets to exclude for a dependency/package reference
+        /// </summary>
         public const string ExcludeAssets = nameof(ExcludeAssets);
+
+        /// <summary>
+        /// Same as <see cref="IncludeAssets"/>, but allows having a different value for the
+        /// included assets in pack vs build/restore of the referencing project.
+        /// </summary>
+        public const string PackInclude = nameof(PackInclude);
+
+        /// <summary>
+        /// Same as <see cref="ExcludeAssets"/>, but allows having a different value for the
+        /// excluded assets in pack vs build/restore of the referencing project.
+        /// </summary>
+        public const string PackExclude = nameof(PackExclude);
 
         /// <summary>
         /// Whether the project can be packed as a .nupkg.

--- a/src/NuGetizer.Tests/CreatePackageTests.cs
+++ b/src/NuGetizer.Tests/CreatePackageTests.cs
@@ -331,6 +331,58 @@ namespace NuGetizer
         }
 
         [Fact]
+        public void when_creating_package_with_dependency_packinclude_then_contains_dependency_include_attribute()
+        {
+            task.Contents = new[]
+            {
+                new TaskItem("Newtonsoft.Json", new Metadata
+                {
+                    { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+                    { MetadataName.PackFolder, PackFolderKind.Dependency },
+                    { MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net472" },
+                    { MetadataName.PackInclude, "build" }
+                }),
+            };
+
+            var manifest = ExecuteTask();
+
+            Assert.NotNull(manifest);
+            Assert.Single(manifest.Metadata.DependencyGroups);
+            Assert.Single(manifest.Metadata.DependencyGroups.First().Packages);
+            Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+            Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.First().Include.Count);
+            Assert.Equal("build", manifest.Metadata.DependencyGroups.First().Packages.First().Include[0]);
+        }
+
+        [Fact]
+        public void when_creating_package_with_dependency_packexclude_assets_then_contains_dependency_exclude_attribute()
+        {
+            task.Contents = new[]
+            {
+                new TaskItem("Newtonsoft.Json", new Metadata
+                {
+                    { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
+                    { MetadataName.PackFolder, PackFolderKind.Dependency },
+                    { MetadataName.Version, "8.0.0" },
+					// NOTE: AssignPackagePath takes care of converting TFM > short name
+					{ MetadataName.TargetFramework, "net472" },
+                    { MetadataName.PackExclude, "build" }
+                }),
+            };
+
+            var manifest = ExecuteTask();
+
+            Assert.NotNull(manifest);
+            Assert.Single(manifest.Metadata.DependencyGroups);
+            Assert.Single(manifest.Metadata.DependencyGroups.First().Packages);
+            Assert.Equal("Newtonsoft.Json", manifest.Metadata.DependencyGroups.First().Packages.First().Id);
+            Assert.Equal(1, manifest.Metadata.DependencyGroups.First().Packages.First().Exclude.Count);
+            Assert.Equal("build", manifest.Metadata.DependencyGroups.First().Packages.First().Exclude[0]);
+        }
+
+        [Fact]
         public void when_creating_package_with_non_framework_secific_dependency_then_contains_generic_dependency_group()
         {
             task.Contents = new[]

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -722,11 +722,8 @@ namespace NuGetizer
                 """
                 <Project Sdk="Microsoft.NET.Sdk">
                 	<PropertyGroup>
-                		<OutputType>Exe</OutputType>
-                		<TargetFramework>net472</TargetFramework>
-                		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-                		<PackageId>TestNuGetizer</PackageId>
-                		<LangVersion>Latest</LangVersion>
+                        <IsPackable>true</IsPackable>
+                        <TargetFramework>net472</TargetFramework>
                 	</PropertyGroup>
 
                 	<ItemGroup>
@@ -745,6 +742,36 @@ namespace NuGetizer
             Assert.Contains(result.Items, item => item.Matches(new
             {
                 PathInPackage = "lib/net461/System.Memory.dll",
+            }));
+        }
+
+        [Fact]
+        public void when_packing_dependencies_then_can_include_exclude_assets()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                	<PropertyGroup>
+                		<OutputType>Exe</OutputType>
+                		<TargetFramework>net472</TargetFramework>
+                        <IsPackable>true</IsPackable>
+                        <LangVersion>Latest</LangVersion>
+                	</PropertyGroup>
+                
+                	<ItemGroup>
+                		<PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" IncludeAssets="analyzers" ExcludeAssets="build" />
+                	</ItemGroup>
+                </Project>
+                """, output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "Devlooped.SponsorLink",
+                PackFolder = "Dependency",
+                IncludeAssets = "analyzers",
+                ExcludeAssets = "build"
             }));
         }
     }


### PR DESCRIPTION
We currently surface the PackageReference's IncludeAssets/ExcludeAssets as the ultimate dependency Include/Exclude metadata attributes. This is not always what you want, though.

For example: if you need the compile dependency for compiling the project, but only want to surface the dependency as a build dependency, you cannot exclude the compile asset because your project depends on the lib to build.

In order to make this more intuitive and aligned with the other attributes, we introduce PackInclude/PackExclude attributes for that purpose, which map exactly to the .nuspec: https://learn.microsoft.com/en-us/nuget/reference/nuspec#dependencies-element.

Note that the existing behavior will be overriden if those attributes are provided, which provides backwards compatibility.