### PR TITLE
Only surface build and analyzer from SponsorLink

### DIFF
--- a/src/CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CodeAnalysis/CodeAnalysis.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" Visible="false" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.2.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When referencing NuGetizer, no SponsorLink APIs should be exposed to consumers