### PR TITLE
Fix support for platform-suffixed build output

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -194,7 +194,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-  <Target Name="_CollectInferenceCandidates" Inputs="@(PackInference)" Outputs="%(PackInference.Identity)-BATCH">
+  <Target Name="_CollectInferenceCandidates" Inputs="@(PackInference)" Outputs="|%(PackInference.Identity)|">
     <PropertyGroup>
       <PackExclude>%(PackInference.PackExclude)</PackExclude>
       <PackInferenceIdentity>%(PackInference.Identity)</PackInferenceIdentity>
@@ -303,12 +303,14 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      @(_SatelliteDllsProjectOutputGroupOutput -> '%(FinalOutputPath)')">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <TargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFramework)</TargetFramework>
       </_InferredProjectOutput>
 
       <_InferredProjectOutput Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                             Condition="'$(PackSymbols)' != 'false'">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <TargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFramework)</TargetFramework>
       </_InferredProjectOutput>
 
       <_InferredPackageFile Include="@(_InferredProjectOutput -> Distinct())" />

--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -67,6 +67,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <OriginalItemSpec />
       <!-- Don't show package files in project explorer by default -->
       <Visible>false</Visible>
+      <TargetFramework />
+      <TargetFrameworkMoniker />
     </PackageFile>
     <PackageReference>
       <!-- See https://github.com/NuGet/Home/wiki/PackageReference-Specification -->

--- a/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uilibrary.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_multitargeting_libraries/uilibrary.csproj
@@ -2,11 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    <UseWPF>true</UseWPF>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TargetFrameworks>net7.0;net7.0-windows;net7.0-maccatalyst</TargetFrameworks>
+    <PackOnBuild>true</PackOnBuild>
     <IsPackable>true</IsPackable>
-    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGetizer.Tests/given_multitargeting_libraries.cs
+++ b/src/NuGetizer.Tests/given_multitargeting_libraries.cs
@@ -37,5 +37,34 @@ namespace NuGetizer
 
             Assert.True(File.Exists(result.Items[0].GetMetadata("FullPath")));
         }
+
+        [Fact]
+        public void when_getting_content_then_multitargets()
+        {
+            Builder.BuildScenario(
+                nameof(given_multitargeting_libraries),
+                projectName: "uilibrary.csproj", target: "Restore", output: output)
+                .AssertSuccess(output);
+
+            var result = Builder.BuildScenario(
+                nameof(given_multitargeting_libraries),
+                projectName: "uilibrary.csproj",
+                target: "GetPackageContents", output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net7.0/uilibrary.dll"
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net7.0-windows/uilibrary.dll"
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net7.0-maccatalyst/uilibrary.dll"
+            }));
+        }
     }
 }


### PR DESCRIPTION
Turns out that the new-ish platform-suffixed TF names (i.e. net7.0-windows, net7.0-maccatalyst and so on) all end up being the same TFM (.NETCoreApp, Version=7.0), which ends up packing assets to duplicate package paths in pack inference.

It seems like we might need to rethink nugetier reliance on the TFM for most of its multi-targeting and TF-specific packing. We currently use the TFM as the default to determine target package path, unless a TF is specified for an item. This ends up being incorrect if the TF contains a platform suffix, as noted.

For now, provide a specific and localized fix for just primary output assembly, symbols and docs.

We should do an extensive examination of other scenarios for xplat MAUI packages.