### PR TITLE
Improve the handling of platform-suffixed target frameworks

### DIFF
--- a/src/NuGetizer.Tasks/AssignPackagePath.cs
+++ b/src/NuGetizer.Tasks/AssignPackagePath.cs
@@ -78,13 +78,13 @@ namespace NuGetizer.Tasks
 
             output.SetMetadata(MetadataName.PackageFolder, packageFolder.Replace('\\', '/'));
 
-            // NOTE: a declared TargetFramework metadata trumps TargetFrameworkMoniker, 
+            // NOTE: a declared TargetFramework metadata trumps the DefaultTargetFramework  
             // which is defaulted to that of the project being built.
             var targetFramework = output.GetMetadata(MetadataName.TargetFramework);
             if (string.IsNullOrEmpty(targetFramework) && frameworkSpecific)
             {
-                var frameworkMoniker = file.GetTargetFrameworkMoniker();
-                targetFramework = frameworkMoniker.GetShortFrameworkName() ?? "";
+                var nugetFramework = file.GetNuGetTargetFramework(frameworkSpecific);
+                targetFramework = nugetFramework?.GetShortFolderName() ?? "";
                 // At this point we have the correct target framework
                 output.SetMetadata(MetadataName.TargetFramework, targetFramework);
             }

--- a/src/NuGetizer.Tasks/Extensions.cs
+++ b/src/NuGetizer.Tasks/Extensions.cs
@@ -85,55 +85,22 @@ namespace NuGetizer
             }
         }
 
-        public static NuGetFramework GetNuGetTargetFramework(this ITaskItem taskItem)
+        public static NuGetFramework? GetNuGetTargetFramework(this ITaskItem taskItem, bool? frameworkSpecific = default)
         {
-            if (bool.TryParse(taskItem.GetMetadata(MetadataName.FrameworkSpecific), out var frameworkSpecific) &&
-                !frameworkSpecific)
+            if (bool.TryParse(taskItem.GetMetadata(MetadataName.FrameworkSpecific), out var fws))
+                frameworkSpecific = fws;
+
+            if (frameworkSpecific != true)
                 return NuGetFramework.AnyFramework;
 
             var metadataValue = taskItem.GetMetadata(MetadataName.TargetFramework);
             if (string.IsNullOrEmpty(metadataValue))
-                metadataValue = taskItem.GetMetadata(MetadataName.TargetFrameworkMoniker);
+                metadataValue = taskItem.GetMetadata(MetadataName.DefaultTargetFramework);
 
             if (!string.IsNullOrEmpty(metadataValue))
                 return NuGetFramework.Parse(metadataValue);
             else
-                return NuGetFramework.AnyFramework;
-        }
-
-        public static FrameworkName GetTargetFramework(this ITaskItem taskItem)
-        {
-            var metadataValue = taskItem.GetMetadata(MetadataName.TargetFramework);
-            if (string.IsNullOrEmpty(metadataValue))
-                metadataValue = taskItem.GetMetadata(MetadataName.TargetFrameworkMoniker);
-
-            if (!string.IsNullOrEmpty(metadataValue))
-                return new FrameworkName(NuGetFramework.Parse(metadataValue).DotNetFrameworkName);
-            else
-                return NullFramework;
-        }
-
-        public static FrameworkName GetTargetFrameworkMoniker(this ITaskItem item)
-        {
-            var value = item.GetMetadata(MetadataName.TargetFrameworkMoniker);
-            // \o/: Turn .NETPortable,Version=v5.0 into .NETPlatform,Version=v5.0, hardcoded for now?
-            // TODO: should be able to get .NETStandard,Version=v1.x from the item metadata somehow.
-
-            return string.IsNullOrEmpty(value) ?
-                NullFramework :
-                new FrameworkName(value);
-        }
-
-        public static string GetShortFrameworkName(this FrameworkName frameworkName)
-        {
-            if (frameworkName == null || frameworkName == NullFramework)
                 return null;
-
-            // In this case, NuGet returns portable50, is that correct?
-            //if (frameworkName.Identifier == ".NETPortable" && frameworkName.Version.Major == 5 && frameworkName.Version.Minor == 0)
-            //	return "dotnet";
-
-            return NuGetFramework.Parse(frameworkName.FullName).GetShortFolderName();
         }
 
         public static void LogErrorCode(this TaskLoggingHelper log, string code, string message, params object[] messageArgs) =>

--- a/src/NuGetizer.Tasks/MetadataName.cs
+++ b/src/NuGetizer.Tasks/MetadataName.cs
@@ -62,9 +62,15 @@
         /// </summary>
         public const string FrameworkSpecific = nameof(FrameworkSpecific);
 
+        /// <summary>
+        /// The target framework of an item.
+        /// </summary>
         public const string TargetFramework = nameof(TargetFramework);
 
-        public const string TargetFrameworkMoniker = nameof(TargetFrameworkMoniker);
+        /// <summary>
+        /// The original (and therefore default) target framework of the project that declared an item.
+        /// </summary>
+        public const string DefaultTargetFramework = nameof(DefaultTargetFramework);
 
         /// <summary>
         /// Available optional metadata values of contentFiles.

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -181,6 +181,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetPackageContentsDependsOn>
       $(GetPackageContentsDependsOn);
       _SetDefaultPackageReferencePack;
+      _SetPackTargetFramework;
       InferPackageContents
     </GetPackageContentsDependsOn>
   </PropertyGroup>
@@ -303,14 +304,12 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      @(_SatelliteDllsProjectOutputGroupOutput -> '%(FinalOutputPath)')">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
-        <TargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFramework)</TargetFramework>
       </_InferredProjectOutput>
 
       <_InferredProjectOutput Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                             Condition="'$(PackSymbols)' != 'false'">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
-        <TargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFramework)</TargetFramework>
       </_InferredProjectOutput>
 
       <_InferredPackageFile Include="@(_InferredProjectOutput -> Distinct())" />
@@ -324,6 +323,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        '%(PackageReference.PrivateAssets)' != 'all' and
                                        '%(PackageReference.Pack)' != 'false'">
         <PackFolder>Dependency</PackFolder>
+        <!--<FrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == 'true'">true</FrameworkSpecific>-->
       </_InferredPackageFile>
 
       <!-- We can't use %(FrameworkFile)==true because it's not defined for raw file references and 
@@ -346,7 +346,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Source>Implicit</Source>
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <OriginalTargetFramework>$(PackTargetFramework)</OriginalTargetFramework>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.MultiTargeting.targets
@@ -70,14 +70,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output ItemName="_PackageContent" TaskParameter="TargetOutputs" />
     </MSBuild>
   
-    <!-- _AddPackageManifest adds per-TFM, so deduplicate and remove the TFM -->
+    <!-- _AddPackageManifest adds per-TFM, so deduplicate and remove the TF(M) -->
     <ItemGroup Condition="'$(IsPackable)' == 'true'">
       <_PackageMetadataContent Include="@(_PackageContent -> WithMetadataValue('PackFolder', 'Metadata'))" />
       <_PackageContent Remove="@(_PackageMetadataContent)" />
       <_PackageContent Include="@(_PackageMetadataContent -> Distinct())">
         <AdditionalProperties />
         <Platform>$(Platform)</Platform>
-        <TargetFrameworkMoniker />
+        <TargetFramework />
+        <DefaultTargetFramework />
+        <OriginalTargetFramework />
       </_PackageContent>
     </ItemGroup>
     

--- a/src/NuGetizer.Tasks/NuGetizer.props
+++ b/src/NuGetizer.Tasks/NuGetizer.props
@@ -68,7 +68,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Don't show package files in project explorer by default -->
       <Visible>false</Visible>
       <TargetFramework />
-      <TargetFrameworkMoniker />
+      <!-- The (pack) target framework of the originating project -->
+      <OriginalTargetFramework />
+      <!-- The determined default (pack) target framework of an inferred item -->
+      <DefaultTargetFramework />
     </PackageFile>
     <PackageReference>
       <!-- See https://github.com/NuGet/Home/wiki/PackageReference-Specification -->

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -46,6 +46,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetPackageContentsDependsOn>
       $(GetPackageContentsDependsOn);
       GetPackageTargetPath;
+      _SetPackTargetFramework;
       _AddPackageManifest
     </GetPackageContentsDependsOn>
     <GetPackageContentsDependsOn Condition="'$(PackProjectReferences)' == 'true'">
@@ -64,7 +65,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageFile>
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform Condition="'%(PackageFile.Platform)' == ''">$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'%(PackageFile.TargetFrameworkMoniker)' == '' and ('$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true')">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <DefaultTargetFramework Condition="'%(PackageFile.DefaultTargetFramework)' == '' and ('$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true')">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
 
@@ -126,7 +127,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackFolder>Metadata</PackFolder>
         <PackageId>$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
   </Target>
@@ -167,7 +168,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                                '%(_ReferencedPackageContent.PackFolder)' == 'Metadata'">
         <!-- For consistency, annotate like the rest -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
-        <TargetFrameworkMoniker Condition="'$(IsPackagingProject)' != 'true'  or '$(BuildOutputFrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true'  or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
         <PackFolder>Dependency</PackFolder>
       </_ReferencedPackageDependency>
       <!-- Remove the referenced package actual contents if it provides a manifest, since it will be a dependency in that case. -->
@@ -181,7 +182,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Always annotate package contents with the original target framework and moniker -->
       <_ReferencedPackageContentWithOriginalValues Include="@(_ReferencedPackageContent)"
                                                    OriginalTargetFramework="%(_ReferencedPackageContent.TargetFramework)"
-                                                   OriginalTargetFrameworkMoniker="%(_ReferencedPackageContent.TargetFrameworkMoniker)" />
+                                                   OriginalDefaultTargetFramework="%(_ReferencedPackageContent.DefaultTargetFramework)" />
     </ItemGroup>
 
     <!-- We don't retarget referenced content for packaging projects that aren't framework specific, and
@@ -193,17 +194,17 @@ Copyright (c) .NET Foundation. All rights reserved.
         <!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
         <!-- Only do this for assets that come from project references that don't build nugets (PackageId=='' above) -->
         <TargetFramework></TargetFramework>
-        <!-- NOTE: we're always overwriting the TFM for framework-specific items in this case 
+        <!-- NOTE: we're always overwriting the default TF for framework-specific items in this case 
           since this item will end up making up the contents of this project package in its 
-          current TFM configuration. 
+          current TF configuration. 
           TBD: we might want to preserve it anyways and adjust later (i.e. net45 project 
           references netstandard1.6 project)
           TODO: take into account cross-targeting.
 		-->
-        <TargetFrameworkMoniker Condition="'%(_ReferencedPackageContentWithOriginalValues.FrameworkSpecific)' == 'true'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <DefaultTargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.FrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
         <!-- Transitive dependencies from non-packing projects should be lifted as direct dependencies of the packing project, 
              using its TFM, since they would need to become dependencies of the packing project in the current TFM. -->
-        <TargetFrameworkMoniker Condition="'%(_ReferencedPackageContentWithOriginalValues.PackFolder)' == 'Dependency'">$(TargetFrameworkMoniker)</TargetFrameworkMoniker>
+        <DefaultTargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.PackFolder)' == 'Dependency'">$(PackTargetFramework)</DefaultTargetFramework>
       </_ReferencedPackageContentWithOriginalValues>
     </ItemGroup>
 
@@ -212,11 +213,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
         <!-- Assign current package id if appropriate -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
-        <!-- Clear the target framework since it trumps the TFM in AsignPackagePath now -->
+        <!-- Clear the target framework since it trumps the default TF in AsignPackagePath now -->
         <!-- Only do this for framework-specifc assets that come from project references that don't build nugets (PackageId=='' above) -->
         <TargetFramework Condition="'%(_ReferencedPackageContentWithOriginalValues.FrameworkSpecific)' == 'true'"></TargetFramework>
-        <TargetFrameworkMoniker>%(_ReferencedPackageContentWithOriginalValues.OriginalTargetFrameworkMoniker)</TargetFrameworkMoniker>
-      </_ReferencedPackageContentWithOriginalValues>
+        <DefaultTargetFramework>%(_ReferencedPackageContentWithOriginalValues.OriginalDefaultTargetFramework)</DefaultTargetFramework>
+    </_ReferencedPackageContentWithOriginalValues>
     </ItemGroup>
 
     <ItemGroup>
@@ -234,7 +235,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_SplitProjectReferencesByIsNuGetized"
           Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''"
           Inputs="@(_MSBuildProjectReferenceExistent)"
-          Outputs="%(_MSBuildProjectReferenceExistent.Identity)-BATCH">
+          Outputs="|%(_MSBuildProjectReferenceExistent.Identity)|">
 
     <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
              Targets="GetTargetPathWithTargetPlatformMoniker"
@@ -294,6 +295,18 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <BuildOutputFrameworkSpecific>@(_BuildOutputFrameworkSpecific)</BuildOutputFrameworkSpecific>
       <BuildOutputFrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == ''">false</BuildOutputFrameworkSpecific>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Ensures that for platform-suffixed target frameworks, we append the target platform version, which is required in that case from .NET5+ -->
+  <Target Name="_SetPackTargetFramework">
+    <PropertyGroup Condition="$(UsingMicrosoftNETSdk) == true">
+      <PackTargetFramework>$(TargetFramework)</PackTargetFramework>
+      <PackTargetFramework Condition="$(TargetFramework.EndsWith($(TargetPlatformIdentifier.ToLowerInvariant())))">$(TargetFramework)$(TargetPlatformVersion)</PackTargetFramework>
+    </PropertyGroup>
+    <!-- This makes NuGetizer backwards compatible with non-SDK projects, since we can parse a moniker just fine too -->
+    <PropertyGroup Condition="$(UsingMicrosoftNETSdk) != true">
+      <PackTargetFramework>$(TargetFrameworkMoniker)</PackTargetFramework>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGetizer.Tests/AssignPackagePathTests.cs
+++ b/src/NuGetizer.Tests/AssignPackagePathTests.cs
@@ -89,7 +89,7 @@ namespace NuGetizer
                     new TaskItem("library.dll", new Metadata
                     {
                         { "PackagePath", "workbooks/library.dll" },
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "FrameworkSpecific", "true" }
                     })
                 }
@@ -143,7 +143,7 @@ namespace NuGetizer
                 {
                     new TaskItem("library.dll", new Metadata
                     {
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.5" },
                         { "PackFolder", "lib" }
                     })
                 }
@@ -165,7 +165,7 @@ namespace NuGetizer
                 {
                     new TaskItem("library.dll", new Metadata
                     {
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "PackFolder", "lib" }
                     })
                 }
@@ -186,7 +186,7 @@ namespace NuGetizer
                 {
                     new TaskItem("library.dll", new Metadata
                     {
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "PackFolder", "lib" }
                     })
                 }
@@ -466,7 +466,7 @@ namespace NuGetizer
                     new TaskItem("library.dll", new Metadata
                     {
                         { "PackageId", "A" },
-                        { "TargetFrameworkMoniker", targetFrameworkMoniker },
+                        { "DefaultTargetFramework", targetFrameworkMoniker },
                         { "PackFolder", "lib" }
                     })
                 }
@@ -504,7 +504,7 @@ namespace NuGetizer
                     new TaskItem("library.dll", new Metadata
                     {
                         { "PackageId", "A" },
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "PackFolder", packageFileKind }
                     })
                 }
@@ -596,7 +596,7 @@ namespace NuGetizer
                     new TaskItem("Sample.cs", new Metadata
                     {
                         { "PackageId", "A" },
-                        { "TargetFrameworkMoniker", tfm },
+                        { "DefaultTargetFramework", tfm },
                         { "PackFolder", "content" },
                         { "CodeLanguage", lang }
                     })
@@ -807,7 +807,7 @@ namespace NuGetizer
                     new TaskItem("sdk/bin/tool.exe", new Metadata
                     {
                         { "PackageId", "A" },
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "PackFolder", "tool" },
                         { "FrameworkSpecific", "true" },
                         { "TargetPath", "sdk/bin/tool.exe"}
@@ -898,7 +898,7 @@ namespace NuGetizer
                     new TaskItem("tools/foo.exe", new Metadata
                     {
                         { "PackageId", "A" },
-                        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.7.2" },
+                        { "DefaultTargetFramework", ".NETFramework,Version=v4.7.2" },
                         { "PackFolder", "tools" },
                     }),
                 }

--- a/src/NuGetizer.Tests/CreatePackageTests.cs
+++ b/src/NuGetizer.Tests/CreatePackageTests.cs
@@ -426,7 +426,7 @@ namespace NuGetizer
         }
 
         [Fact]
-        public void when_creating_package_with_any_framework_secific_dependency_then_contains_generic_dependency_group()
+        public void when_creating_package_with_any_framework_specific_dependency_then_contains_generic_dependency_group()
         {
             task.Contents = new[]
             {
@@ -812,13 +812,13 @@ namespace NuGetizer
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET472 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.NET472 }
                 }),
                 new TaskItem("System.Xml", new Metadata
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.PCL78 }
                 }),
             };
 
@@ -844,25 +844,25 @@ namespace NuGetizer
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET472 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.NET472 }
                 }),
                 new TaskItem("System.Xml", new Metadata
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.NET472 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.NET472 }
                 }),
                 new TaskItem("System.Xml", new Metadata
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.PCL78 }
                 }),
                 new TaskItem("System.Xml", new Metadata
                 {
                     { MetadataName.PackageId, task.Manifest.GetMetadata("Id") },
                     { MetadataName.PackFolder, PackFolderKind.FrameworkReference },
-                    { MetadataName.TargetFrameworkMoniker, TargetFrameworks.PCL78 }
+                    { MetadataName.DefaultTargetFramework, TargetFrameworks.PCL78 }
                 }),
             };
 

--- a/src/NuGetizer.Tests/UtilitiesTests.cs
+++ b/src/NuGetizer.Tests/UtilitiesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Versioning;
 using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
 using Xunit;
 using Metadata = System.Collections.Generic.Dictionary<string, string>;
 
@@ -7,45 +8,60 @@ namespace NuGetizer
 {
     public class UtilitiesTests
     {
+        //[Fact]
+        //public void when_getting_target_framework_then_fallback_to_tfm()
+        //{
+        //    var item = new TaskItem("Foo", new Metadata
+        //    {
+        //        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
+        //    });
+
+        //    var framework = item.GetTargetFramework();
+
+        //    Assert.Equal(new FrameworkName(".NETFramework,Version=v4.5"), framework);
+        //}
+
+        //[Fact]
+        //public void when_getting_target_framework_then_does_not_use_tfm()
+        //{
+        //    var item = new TaskItem("Foo", new Metadata
+        //    {
+        //        { "TargetFramework", "net46" },
+        //        { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
+        //    });
+
+        //    var framework = item.GetTargetFramework();
+
+        //    Assert.Equal(new FrameworkName(".NETFramework,Version=v4.6"), framework);
+        //}
+
+        //[Fact]
+        //public void when_getting_any_target_framework_then_suceeds()
+        //{
+        //    var item = new TaskItem("Foo", new Metadata
+        //    {
+        //        { "TargetFramework", "any" },
+        //    });
+
+        //    var framework = item.GetTargetFramework();
+
+        //    Assert.Equal(new FrameworkName("Any,Version=v0.0"), framework);
+        //    Assert.Equal("any", framework.GetShortFrameworkName());
+        //}
+
         [Fact]
-        public void when_getting_target_framework_then_fallback_to_tfm()
+        public void when_default_target_framework_has_platform_then_uses_target_platform()
         {
             var item = new TaskItem("Foo", new Metadata
             {
-                { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
+                { "FrameworkSpecific", "true" },
+                { "DefaultTargetFramework", "net7.0-windows7.0" },
             });
 
-            var framework = item.GetTargetFramework();
+            var framework = item.GetNuGetTargetFramework();
 
-            Assert.Equal(new FrameworkName(".NETFramework,Version=v4.5"), framework);
+            Assert.Equal("net7.0-windows7.0", framework.GetShortFolderName());
         }
 
-        [Fact]
-        public void when_getting_target_framework_then_does_not_use_tfm()
-        {
-            var item = new TaskItem("Foo", new Metadata
-            {
-                { "TargetFramework", "net46" },
-                { "TargetFrameworkMoniker", ".NETFramework,Version=v4.5" }
-            });
-
-            var framework = item.GetTargetFramework();
-
-            Assert.Equal(new FrameworkName(".NETFramework,Version=v4.6"), framework);
-        }
-
-        [Fact]
-        public void when_getting_any_target_framework_then_suceeds()
-        {
-            var item = new TaskItem("Foo", new Metadata
-            {
-                { "TargetFramework", "any" },
-            });
-
-            var framework = item.GetTargetFramework();
-
-            Assert.Equal(new FrameworkName("Any,Version=v0.0"), framework);
-            Assert.Equal("any", framework.GetShortFrameworkName());
-        }
     }
 }

--- a/src/NuGetizer.Tests/given_multitargeting_libraries.cs
+++ b/src/NuGetizer.Tests/given_multitargeting_libraries.cs
@@ -59,11 +59,11 @@ namespace NuGetizer
             }));
             Assert.Contains(result.Items, item => item.Matches(new
             {
-                PackagePath = "lib/net7.0-windows/uilibrary.dll"
+                PackagePath = "lib/net7.0-windows7.0/uilibrary.dll"
             }));
             Assert.Contains(result.Items, item => item.Matches(new
             {
-                PackagePath = "lib/net7.0-maccatalyst/uilibrary.dll"
+                PackagePath = "lib/net7.0-maccatalyst16.1/uilibrary.dll"
             }));
         }
     }


### PR DESCRIPTION
We previously (ab)used the TargetFrameworkMoniker of a project as a default/fallback target framework to use whenever the TargetFramework metadata was not present for a particular PackageFile.

This broke down in .NET5+ when platform-suffixed TFs such as "net7.0-windows" now need the target platform version, in addition to the TF< which, furthermore, can no longer be recreated as a nuget framework from the TFM alone, since it also contains the TargetPlatformIdentifier.

So rather than complicating the previous single metadata value with *three* (TFM, TPM and a boolean on whether the original TF had a platform suffix or not), we instead normalize this up-front in all projects via a new target, and set this as PackTargetFramework. We then proceed to use this in a new more intention-revealing metadata item, DefaultTargetFramework, which is now much more obvious than "leveraging" the TFM name.