### PR TITLE
Change nugetize default to non-verbose

### DIFF
--- a/src/dotnet-nugetize/Program.cs
+++ b/src/dotnet-nugetize/Program.cs
@@ -26,7 +26,7 @@ class Program
 
     bool binlog = Debugger.IsAttached;
     bool debug = Debugger.IsAttached && Environment.GetEnvironmentVariable("DEBUG_NUGETIZER") != "0";
-    bool quiet = false;
+    bool verbose = false;
     string items;
     List<string> extra;
 
@@ -85,7 +85,7 @@ class Program
             { "?|h|help", "Display this help.", h => help = h != null },
             { "b|bl|binlog", "Generate binlog.", b => binlog = b != null },
             { "d|debug", "Debug nugetizer tasks.", d => debug = d != null, true },
-            { "q|quiet", "Don't render MSBuild output.", q => quiet = q != null },
+            { "v|verbose", "Render MSBuild output.", v => verbose = v != null },
             { "i|items:", "MSBuild items file path containing full package contents metadata.", i => items = Path.GetFullPath(i) },
             { "version", "Render tool version and copyright information.", v => version = v != null },
         }
@@ -455,11 +455,10 @@ class Program
         if (!timedout)
             output.Append(proc.StandardOutput.ReadToEnd());
 
-        if (quiet)
-            return proc.ExitCode == 0;
+        if (!verbose && proc.ExitCode == 0)
+            return true;
 
-        if (timedout || proc.ExitCode != 0)
-            Console.Out.Write(output.ToString());
+        Console.Out.Write(output.ToString());
 
         return proc.ExitCode == 0;
     }


### PR DESCRIPTION
We were showing MSBuild output for any nugetize run that took longer than 10 seconds. Diagnosing slow builds shouldn't be a nugetizer issue, and it makes it confusing to see potentially many warnings and what-not that are irrelevant to packing.

Make it so instead of asking for quiet, you can ask for verbose and get the output.

If there were errors running the tool, we'd still want to see the MSBuild output, though.