### PR TITLE
Ensure transitive dependencies are properly resolved for inference

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -39,6 +39,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <_OutputFullPath Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</_OutputFullPath>
     <_OutputFullPath Condition="'$(_OutputFullPath)' == ''">$(MSBuildProjectDirectory.TrimEnd('\'))\$(OutputPath)</_OutputFullPath>
+
+    <!-- Ensure built-in RunResolvePackageDependencies target emits stuff we need for inference of transitive dependencies -->
+    <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Readme" Condition="'$(PackReadme)' == 'true' and '$(IsPackable)' == 'true'">

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -774,5 +774,31 @@ namespace NuGetizer
                 ExcludeAssets = "build"
             }));
         }
+
+        [Fact]
+        public void when_private_assets_then_packs_transitively()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                	<PropertyGroup>
+                		<TargetFramework>net6.0</TargetFramework>
+                        <IsPackable>true</IsPackable>
+                	</PropertyGroup>
+                
+                	<ItemGroup>
+                		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" PrivateAssets="all" />
+                	</ItemGroup>
+                </Project>
+                """, output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                NuGetPackageId = "Microsoft.Extensions.Configuration.Abstractions",
+                PackFolder = "Lib",
+            }));
+        }
     }
 }


### PR DESCRIPTION
.NET 7.0 SDK changed from:

```xml
    <ResolvePackageDependencies
      ProjectPath="$(MSBuildProjectFullPath)"
      ProjectAssetsFile="$(ProjectAssetsFile)"
      ProjectLanguage="$(Language)"
      EmitLegacyAssetsFileItems="$(EmitLegacyAssetsFileItems)"
      TargetFramework="$(TargetFramework)"
      ContinueOnError="ErrorAndContinue">

      <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
      <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />

      <!-- These outputs only produced when EmitLegacyAssetsFileItems is true -->
      <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
      <Output TaskParameter="FileDefinitions" ItemName="FileDefinitions" />
      <Output TaskParameter="FileDependencies" ItemName="FileDependencies" />
    </ResolvePackageDependencies>
```

to:

```xml
    <ResolvePackageDependencies
      ProjectPath="$(MSBuildProjectFullPath)"
      ProjectAssetsFile="$(ProjectAssetsFile)"
      ProjectLanguage="$(Language)"
      TargetFramework="$(TargetFramework)"
      ContinueOnError="ErrorAndContinue"
      Condition="'$(EmitLegacyAssetsFileItems)' == 'true'">

      <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
      <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
      <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
      <Output TaskParameter="FileDefinitions" ItemName="FileDefinitions" />
      <Output TaskParameter="FileDependencies" ItemName="FileDependencies" />
    </ResolvePackageDependencies>
```

Since the SDK now conditions the execution of the resolve to the value of `EmitLegacyAssetsFileItems`, we need to explicitly set it.

Since this was likely done for performance reasons, only turn on when package inference is active, since we don't use that anywhere else.