### PR TITLE
Allow extending the build with local-only targets

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -21,5 +21,6 @@
   <Target Name="Test" />
 
   <Import Project="NuGetizer.Tasks\NuGetizer.props" Condition="'$(NuGetize)' == 'true'" />
+  <Import Project="Directory.props.user" Condition="Exists('Directory.props.user')" />
 
 </Project>

--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -13,4 +13,6 @@
     <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>
 
+  <Import Project="Directory.targets.user" Condition="Exists('Directory.targets.user')" />
+
 </Project>


### PR DESCRIPTION
These are always ignored and can therefore be tweaked without fear of inadvertently checking them in.