### PR TITLE
Fix nugetize tool for solutions that use project dependencies

### DIFF
--- a/src/dotnet-nugetize/after.sln.targets
+++ b/src/dotnet-nugetize/after.sln.targets
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="RemoveNonNuGetized" BeforeTargets="GetPackageContents">
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)" Condition="%(Extension) == '.metaproj'" />
+    </ItemGroup>
+
     <MSBuild Properties="BuildingSolutionFile=true; CurrentSolutionConfigurationContents=$(CurrentSolutionConfigurationContents); SolutionDir=$(SolutionDir); SolutionExt=$(SolutionExt); SolutionFileName=$(SolutionFileName); SolutionName=$(SolutionName); SolutionPath=$(SolutionPath)" 
              BuildInParallel="True" 
              SkipNonexistentProjects="true" 


### PR DESCRIPTION
Project dependencies is a mechanism to affect the build order in a solution without adding project references. See https://www.cazzulino.com/project-dependencies-as-project-references.html.

In this scenario, MSBuild will emit a .metaproj for the solution and *also* a .metaproj for each project that declares such dependencies, which in turn uses project references for the dependencies *and* the original project. This generated .metaproj, obviously, won't have any of the standard targets, not even GetTargetPath, which means we won't be able to even determine if the project is nugetized or not.

This used to cause the nugetize tool to refuse to process the other projects in a solution.

This change removes such meta projects from the solution so that the other projects can still work. Note that this may result in missing (packable) projects, but the benefit is that you get *some* rendering at least. You can always run nugetize passing the missing projects' contents, but the current experience is clearly far worse than that.