### PR TITLE
Allow running nugetizer on any major .NET version

### DIFF
--- a/src/dotnet-nugetize/dotnet-nugetize.csproj
+++ b/src/dotnet-nugetize/dotnet-nugetize.csproj
@@ -11,6 +11,7 @@
     <PackageId>dotnet-nugetize</PackageId>
     <ToolCommandName>nugetize</ToolCommandName>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
 
     <Title>Discover how NuGetizer packs a project</Title>
     <Description>Run the `nugetize` tool on a folder with a packable project (i.e. it has at least a PackageId value) to see what package structure NuGetizer would produce.</Description>


### PR DESCRIPTION
We don't need to limit to .net6