### PR TITLE
For nugetize tool, consider default description as empty

### DIFF
--- a/src/dotnet-nugetize/Program.cs
+++ b/src/dotnet-nugetize/Program.cs
@@ -296,6 +296,9 @@ class Program
                         x.Name != "NuPkg")
                     .OrderBy(x => x.Name.LocalName))
                 {
+                    if (md.Name.LocalName == "Description" && md.Value == "Package Description")
+                        continue;
+
                     table.AddRow(new Text(md.Name.LocalName), new Text(md.Value));
                 }
 


### PR DESCRIPTION
No point in rendering what's effectively a default value that should never have existed in the first place. NuGetizer flags this as a warning even now.