### PR TITLE
Add warning when Authors == AssemblyName

### DIFF
--- a/src/CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CodeAnalysis/CodeAnalysis.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <PackFolder>analyzers/dotnet</PackFolder>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,10 @@
     <PackageReference Include="ThisAssembly.Strings" Version="1.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="Devlooped.SponsorLink" Version="0.9.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="NuGetizer.CodeAnalysis.targets" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
+++ b/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
@@ -1,0 +1,24 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="IsPacking" />
+    <CompilerVisibleProperty Include="PackageId" />
+    <CompilerVisibleProperty Include="Description" />
+    <CompilerVisibleProperty Include="PackageIcon" />
+    <CompilerVisibleProperty Include="PackageIconUrl" />
+    <CompilerVisibleProperty Include="PackageReadmeFile" />
+    <CompilerVisibleProperty Include="PackageLicenseExpression" />
+    <CompilerVisibleProperty Include="PackageLicenseFile" />
+    <CompilerVisibleProperty Include="PackageLicenseUrl" />
+    <CompilerVisibleProperty Include="SourceControlInformationFeatureSupported" />
+    <CompilerVisibleProperty Include="RepositoryCommit" />
+    <CompilerVisibleProperty Include="RepositoryUrl" />
+    <CompilerVisibleProperty Include="PackageProjectUrl" />
+    <CompilerVisibleProperty Include="EmbedUntrackedSources" />
+    <CompilerVisibleProperty Include="EnableSourceLink" />
+
+    <CompilerVisibleProperty Include="Authors" />
+    <CompilerVisibleProperty Include="AssemblyName" />    
+  </ItemGroup>
+
+</Project>

--- a/src/CodeAnalysis/Resources.resx
+++ b/src/CodeAnalysis/Resources.resx
@@ -132,15 +132,6 @@
   <data name="DefaultDescription_Title" xml:space="preserve">
     <value>Default description detected</value>
   </data>
-  <data name="LongDescription_ID" xml:space="preserve">
-    <value>NG0102</value>
-  </data>
-  <data name="LongDescription_Message" xml:space="preserve">
-    <value>The Description property used for the package must be up to 4000 characters long.</value>
-  </data>
-  <data name="LongDescription_Title" xml:space="preserve">
-    <value>Provided description is too long</value>
-  </data>
   <data name="MissingIcon_Description" xml:space="preserve">
     <value>The PackageIcon project property can specify the path to a JPEG or PNG file to use as the package icon, which will be automatically packed properly.</value>
   </data>
@@ -245,5 +236,19 @@
   </data>
   <data name="SourceLinkEmbed_Description" xml:space="preserve">
     <value>When EmbedUntrackedSources is set to 'true', Source Link will embed in your PDB the items that participated in the compile, but not are included in source control.</value>
+  </data>
+  <data name="DefaultAuthors_ID" xml:space="preserve">
+    <value>NG0102</value>
+  </data>
+  <data name="DefaultAuthors_Title" xml:space="preserve">
+    <value>Default authors detected</value>
+  </data>
+  <data name="DefaultAuthors_Message" xml:space="preserve">
+    <value>Authors metadata matches the project's AssemblyName. The value should match the profile name(s) of the actual package author(s).</value>
+  </data>
+  <data name="DefaultAuthors_Description" xml:space="preserve">
+    <value>Authors project property should contain a comma-separated list of packages authors, matching the profile names on nuget.org. 
+    These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors.</value>
+    <comment>Long-form description</comment>
   </data>
 </root>

--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -17,6 +17,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Adds compatibility targets with Pack SDK -->
   <Import Project="NuGetizer.Compatibility.props" />
+  <!-- Adds CodeAnalysis props and items needed for diagnostics -->
+  <Import Project="NuGetizer.CodeAnalysis.targets" />
 
   <PropertyGroup>
     <!-- Whether to infer package contents -->
@@ -60,23 +62,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup>
     <!-- This is the capability that CPS in .NETStandard/.NETCore uses to enable the Pack context menu. Unify with that -->
     <ProjectCapability Include="Pack" Condition="'$(IsPackable)' == 'true'" />
-
-    <!-- Properties for the analyzers -->
-    <CompilerVisibleProperty Include="IsPacking" />
-    <CompilerVisibleProperty Include="PackageId" />
-    <CompilerVisibleProperty Include="Description" />
-    <CompilerVisibleProperty Include="PackageIcon" />
-    <CompilerVisibleProperty Include="PackageIconUrl" />
-    <CompilerVisibleProperty Include="PackageReadmeFile" />
-    <CompilerVisibleProperty Include="PackageLicenseExpression" />
-    <CompilerVisibleProperty Include="PackageLicenseFile" />
-    <CompilerVisibleProperty Include="PackageLicenseUrl" />
-    <CompilerVisibleProperty Include="SourceControlInformationFeatureSupported" />
-    <CompilerVisibleProperty Include="RepositoryCommit" />
-    <CompilerVisibleProperty Include="RepositoryUrl" />
-    <CompilerVisibleProperty Include="PackageProjectUrl" />
-    <CompilerVisibleProperty Include="EmbedUntrackedSources" />
-    <CompilerVisibleProperty Include="EnableSourceLink" />
   </ItemGroup>
 
   <!-- Extends the built-in GetTargetPathWithTargetPlatformMoniker output to signal that the project has been nugetized -->


### PR DESCRIPTION
The SDKs set this default in Microsoft.NET.DefaultAssemblyInfo.targets, but it's not really a very useful default (like the Description one).

So we flag this as a warning now.

We take over NG0102 since that wasn't active in any way (analyzers never get 4k chars of a property anyway).