### PR TITLE
In nugetize tool, skip Authors metadata if it equals AssemblyName

### DIFF
--- a/src/NuGetizer.Tasks/dotnet-nugetize.targets
+++ b/src/NuGetizer.Tasks/dotnet-nugetize.targets
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_NuspecFile>%(NuspecFile.FullPath)</_NuspecFile>
     </PropertyGroup>
     <ItemGroup>
-      <PackageMetadata Update="@(PackageMetadata)" Nuspec="$(_NuspecFile)" NuPkg="@(PackageTargetPath)" />
+      <PackageMetadata Update="@(PackageMetadata)" Nuspec="$(_NuspecFile)" NuPkg="@(PackageTargetPath)" AssemblyName="$(AssemblyName)" />
       <PackageContent Include="@(_PackageContent)" Exclude="@(PackageMetadata)" />
     </ItemGroup>
     <!-- Force assign path if rendering contents only -->

--- a/src/dotnet-nugetize/Program.cs
+++ b/src/dotnet-nugetize/Program.cs
@@ -289,6 +289,12 @@ class Program
                 var table = new Grid().AddColumn().AddColumn();
                 table.AddRow(new Text("Metadata:", yellow));
 
+                // We use this to detect Authors==AssemblyName and not render the property in that case
+                // since it's effectively like an empty value, akin to the default description.
+                var assemblyName = metadata.Element("AssemblyName");
+                if (assemblyName != null)
+                    assemblyName.Remove();
+
                 foreach (var md in metadata.Elements()
                     .Where(x =>
                         x.Name != "PackageId" &&
@@ -297,6 +303,8 @@ class Program
                     .OrderBy(x => x.Name.LocalName))
                 {
                     if (md.Name.LocalName == "Description" && md.Value == "Package Description")
+                        continue;
+                    if (md.Name.LocalName == "Authors" && md.Value == assemblyName?.Value)
                         continue;
 
                     table.AddRow(new Text(md.Name.LocalName), new Text(md.Value));

--- a/src/dotnet-nugetize/after.sln.targets
+++ b/src/dotnet-nugetize/after.sln.targets
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Target Name="RemoveNonNuGetized" BeforeTargets="GetPackageContents">
+
     <ItemGroup>
       <ProjectReference Remove="@(ProjectReference)" Condition="%(Extension) == '.metaproj'" />
     </ItemGroup>
@@ -14,10 +16,13 @@
              ContinueOnError="true">
       <Output TaskParameter="TargetOutputs" ItemName="ReferencedProjectTargetPath" />
     </MSBuild>
+
     <ItemGroup>
       <NuGetizedTargetPath Include="@(ReferencedProjectTargetPath -> WithMetadataValue('IsNuGetized', 'true'))" />
       <NonNuGetizedTargetPath Include="@(ReferencedProjectTargetPath)" Exclude="@(NuGetizedTargetPath)" />
       <ProjectReference Remove="@(NonNuGetizedTargetPath -> '%(MSBuildSourceProjectFile)')" />
     </ItemGroup>
+
   </Target>
+
 </Project>


### PR DESCRIPTION
This default value, just like the default description, is now a warning and we shouldn't emit it, to keep the actually used metadata more prominent.