### PR TITLE
Improve support for recursive dir inclusion

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="6.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.ProjectManagement" Version="4.2.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.12.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="ThisAssembly.Project" Version="1.2.9" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Strings" Version="1.2.9" PrivateAssets="all" />
     <PackageReference Include="Minimatch" Version="2.0.0" PrivateAssets="all" />

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -954,5 +954,66 @@ namespace NuGetizer
             }));
         }
 
+        [Fact]
+        public void when_packagepath_ends_in_path_then_packs_recursive_dir()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageFile Include="..\img\**\*.*" PackagePath="assets\" />
+                  </ItemGroup>
+                </Project>  
+                """
+                , "GetPackageContents", output, default,
+                ("../img/brand/icon.png", ""),
+                ("../img/docs/screen.png", ""));
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "assets/brand/icon.png",
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "assets/docs/screen.png",
+            }));
+        }
+
+        [Fact]
+        public void when_packagepath_ends_in_path_then_packs_basedir_dir()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageFile Include="..\img\**\*.*" PackagePath="assets\" />
+                  </ItemGroup>
+                </Project>  
+                """
+                , "GetPackageContents", output, default,
+                ("../img/icon.png", ""),
+                ("../img/screen.png", ""));
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "assets/icon.png",
+            }));
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "assets/screen.png",
+            }));
+        }
     }
 }


### PR DESCRIPTION
Consider the scenario where we include multiple files from a relative path that's outside the project directory:

    <PackageFile Include="..\..\docs\**\*.*" PackagePath="docs\" />

In this case, the natural expectation is that starting from the wildcard, the paths are reconstructed under the specified target package path, just as if we had added %(RecursiveDir)%(Filename)%(Extension) at the end of the `docs\` expression.

We don't do that right now, just appending a relative path that is invalid since it goes outside the package root scope (we add the full `..\..\` as part of concatenating the `RelativeDir`, which includes that).

Granted, this can be worked-around by just constructing the right package path via MSBuild or setting a Link property, but it should Just Work OOB.

This commit adds that support, including the (tricky) scenario where RecursiveDir isn't populated at all, as in the case of a file under ..\..\docs\foo.txt above (since the ** won't have matched any subdirs, it will be empty). So we need to detect the scenario by reading the actual wildcard include, if any.