### PR TITLE
Automatically pack dependencies satellite resources for private packages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,8 @@ Whether items are packed by default or not is controlled by properties named aft
 | PackBuildOutput | true |
 | PackReadme      | true |
 | PackSymbols     | true if PackBuildOutput=true (*) |
-| PackDependencies| empty (**) |
+| PackSatelliteDlls | true if PackBuildOutput=true (**) |
+| PackDependencies| empty (***) |
 | PackFrameworkReferences | true if PackFolder=lib, false if PackDependencies=false |
 | PackProjectReferences | true |
 
@@ -239,7 +240,10 @@ Whether items are packed by default or not is controlled by properties named aft
 \* Back in the day, PDBs were Windows-only and fat files. Nowadays, portable PDBs 
    (the new default) are lightweight and can even be embedded. Combined with [SourceLink](https://github.com/dotnet/sourcelink), including them in the package (either standalone or embeded) provides the best experience for your users, so it's the default.
 
-\** In some scenarios, you might want to turn off packing behavior for all PackageReference and FrameworkReferences alike. Setting PackDependencies=false achieves that.
+\** Satellite resources can come from the main project or from dependencies, if those PackageReferences 
+    have `PrivateAssets=all`.
+
+\*** In some scenarios, you might want to turn off packing behavior for all PackageReference and FrameworkReferences alike. Setting PackDependencies=false achieves that.
 
 
 The various supported item inference are surfaced as `<PackInference Include="Compile;Content;None;..." />` items, which are ultimately evaluated together with the metadata for the individual items. These make the package inference candidates. You can also provide an exclude expression for that evaluation so that certain items are excluded by default, even if every other item of the same type is included. For example, to pack all `Content` items, except those in the `docs` folder, you can simply update the inference item like so:

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -22,11 +22,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Whether to include @(Content) items with CopyToOutputDirectory != '' in the package -->
     <PackContent Condition="'$(PackContent)' == ''">true</PackContent>
-    
+
     <!-- Whether to include @(BuiltProjectOutputGroupOutput), @(DocumentationProjectOutputGroupOutput) and @(SatelliteDllsProjectOutputGroupOutput) items in the package -->
     <!-- When packing as a tool (SDK compatibility mode), primary output should not be packed by us, since the SDK PackTool target will already collect the output of /publish instead. -->
     <PackBuildOutput Condition="'$(PackBuildOutput)' == '' and '$(IsPackagingProject)' != 'true' and '$(PackAsTool)' != 'true'">true</PackBuildOutput>
-        
+
+    <!-- Whether to @(SatelliteDllsProjectOutputGroupOutput) items in the package. Used when inferring for PackBuildOutput=true -->
+    <PackSatelliteDlls Condition="'$(PackSatelliteDlls)' == '' and '$(PackBuildOutput)' == 'true'">true</PackSatelliteDlls>
+
     <!-- Whether to include @(DebugSymbolsProjectOutputGroupOutput) items in the package -->
     <PackSymbols Condition="'$(PackSymbols)' == '' and '$(PackBuildOutput)' == 'true'">true</PackSymbols>
 
@@ -187,7 +190,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       _SetPackTargetFramework;
       InferPackageContents
     </GetPackageContentsDependsOn>
-    
+
   </PropertyGroup>
 
   <Target Name="_SetDefaultPackageReferencePack" Condition="'$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive'"
@@ -215,15 +218,15 @@ Copyright (c) .NET Foundation. All rights reserved.
             PackagePath="%(None.Link)"
             Condition="%(None.Identity) == '$(PackageIcon)' or %(None.Link) == '$(PackageIcon)'" />
 
-      <Content Update="@(Content)" 
+      <Content Update="@(Content)"
                Pack="true"
                BuildAction="None"
                PackFolder="None"
-               PackagePath="%(Content.Link)" 
-               Condition="%(Content.Identity) == '$(PackageIcon)' or %(Content.Link) == '$(PackageIcon)'" />      
+               PackagePath="%(Content.Link)"
+               Condition="%(Content.Identity) == '$(PackageIcon)' or %(Content.Link) == '$(PackageIcon)'" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="_CollectInferenceCandidates" Inputs="@(PackInference)" Outputs="|%(PackInference.Identity)|">
     <PropertyGroup>
       <PackExclude>%(PackInference.PackExclude)</PackExclude>
@@ -295,7 +298,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageIconFilename Condition="'$(PackageIconExists)' == 'true'">@(_PackageIcon -> '%(Filename)')</PackageIconFilename>
       <PackageIconExtension Condition="'$(PackageIconExists)' == 'true'">@(_PackageIcon -> '%(Extension)')</PackageIconExtension>
     </PropertyGroup>
-    
+
     <!-- Even if all these conditions are false, the user can still explicitly pack the icon file, of course -->
     <ItemGroup Label="Icon" Condition="'$(PackageIcon)' != ''">
       <_ExistingIcon Include="@(None -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))" />
@@ -308,7 +311,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                           PackagePath="%(Filename)%(Extension)"
                           Condition="'%(Extension)' == '$(PackageReadmeExtension)'" />
     </ItemGroup>
-    
+
     <ItemGroup>
       <InferenceCandidate>
         <ShouldPack Condition="('%(Pack)' == 'true' or '%(PackagePath)' != '' or '%(PackFolder)' != '' or '%(PackageReference)' != '') and '%(Pack)' != 'false'">true</ShouldPack>
@@ -348,7 +351,8 @@ Copyright (c) .NET Foundation. All rights reserved.
            .NETFramework, the desktop WinFX.targets are imported which don't have the fix, so we need to 
            do it "the old way" for this particular output group -->
       <_SatelliteDllsProjectOutputGroupOutput Include="@(SatelliteDllsProjectOutputGroupOutput)"
-                                              FinalOutputPath="%(FullPath)" />
+                                              FinalOutputPath="%(FullPath)"
+                                              Condition="'$(PackSatelliteDlls)' != 'false'"/>
 
       <_InferredProjectOutput Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)');
                                      @(BuiltProjectOutputGroupKeyOutput -> '%(FinalOutputPath)');
@@ -359,12 +363,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       </_InferredProjectOutput>
 
       <_InferredProjectOutput Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
-                            Condition="'$(PackSymbols)' != 'false'">
+                              Condition="'$(PackSymbols)' != 'false'">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
       </_InferredProjectOutput>
 
       <_InferredPackageFile Include="@(_InferredProjectOutput -> Distinct())" />
+    </ItemGroup>
+
+    <ItemGroup Label="SatelliteDll Resources from Dependencies" Condition="'$(PackBuildOutput)' == 'true' and '$(PackAsPublish)' != 'true'">
+      <!-- Include transitive resources if their NuGetPackageId has PrivateAssets=all and Pack!=false only. -->
+      <_InferredPackageFile Include="@(ResourceCopyLocalItems)"
+                            PackFolder="$(PackFolder)"
+                            TargetPath="%(ResourceCopyLocalItems.DestinationSubPath)"
+                            FrameworkSpecific="$(BuildOutputFrameworkSpecific)"
+                            Condition="$(PrivatePackageReferenceIds.Contains(';%(ResourceCopyLocalItems.NuGetPackageId);'))" />
     </ItemGroup>
 
     <ItemGroup Label="Publishable Inference" Condition="'$(PackAsPublish)' == 'true' and '$(PackAsTool)' != 'true'">
@@ -446,8 +459,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </Target>
 
-  <Target Name="_CollectPrimaryOutputDependencies" 
-          DependsOnTargets="ReferenceCopyLocalPathsOutputGroup;RunResolvePackageDependencies" 
+  <Target Name="_CollectPrimaryOutputDependencies"
+          DependsOnTargets="ReferenceCopyLocalPathsOutputGroup;RunResolvePackageDependencies"
           Returns="@(ImplicitPackageReference)">
     <Error Code="NG1003" Text="Centrally managed package versions is only supported when using the Microsoft.NET.Sdk."
            Condition="'$(ManagePackageVersionsCentrally)' == 'true' and '$(UsingMicrosoftNETSdk)' != 'true'" />
@@ -474,14 +487,23 @@ Copyright (c) .NET Foundation. All rights reserved.
                                    PackageDependencies="@(PackageDependencies)">
       <Output TaskParameter="ImplicitPackageReferences" ItemName="ImplicitPackageReference" />
     </InferImplicitPackageReference>
+
+    <ItemGroup>
+      <_PrivatePackageReference Include="@(PackageReference)" Condition="%(PackageReference.Pack) != 'false' and '%(PackageReference.PrivateAssets)' == 'all'" />
+      <_PrivatePackageReference Include="@(ImplicitPackageReference)" Condition="%(PackageReference.Pack) != 'false' and '%(PackageReference.PrivateAssets)' == 'all'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <PrivatePackageReferenceIds>;@(_PrivatePackageReference);</PrivatePackageReferenceIds>
+    </PropertyGroup>
+
   </Target>
 
   <Target Name="_ResolvePackageDependencies" Condition="'$(UsingMicrosoftNETSdk)' == 'true'" DependsOnTargets="RunResolvePackageDependencies" />
 
   <Target Name="InferPrimaryOutputDependencies"
-          Condition="'$(PackAsTool)' != 'true' and '$(PackAsPublish)' != 'true'" 
+          Condition="'$(PackAsTool)' != 'true' and '$(PackAsPublish)' != 'true'"
           Inputs="@(_PrimaryOutputRelatedFile)"
-          Outputs="%(_PrimaryOutputRelatedFile.NuGetPackageId)"
+          Outputs="|%(_PrimaryOutputRelatedFile.NuGetPackageId)|"
           Returns="@(_InferredPackageFile)"
           DependsOnTargets="_ResolvePackageDependencies;_CollectPrimaryOutputDependencies">
 

--- a/src/NuGetizer.Tests/given_packinference.cs
+++ b/src/NuGetizer.Tests/given_packinference.cs
@@ -595,5 +595,38 @@ namespace NuGetizer
                 Extension = ".dll",
             }));
         }
+
+        [Fact]
+        public void when_packing_dependencies_then_includes_satellite_resources_for_private_assets()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                	<PropertyGroup>
+                		<OutputType>Exe</OutputType>
+                		<TargetFramework>netstandard2.0</TargetFramework>
+                        <IsPackable>true</IsPackable>
+                        <LangVersion>Latest</LangVersion>
+                	</PropertyGroup>
+                
+                	<ItemGroup>
+                		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+                	</ItemGroup>
+                </Project>
+                """, output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.resources.dll",
+            }));
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/netstandard2.0/es/Microsoft.CodeAnalysis.resources.dll",
+            }));
+        }
+
     }
 }


### PR DESCRIPTION
Added a new `PackSatelliteDlls` property that can be set to `false` to avoid packing the satellite resource assemblies when the project is localized. This setting only applies when `PackBuildOutput=true`.

When a `PackageReference` has `PrivateAssets=all`, we assume all assets should be packed alongside the primary output (just as you would see them in the build output). Package references that include satellite resources will show up in the output directory, so it makes sense to also pack them in this case.