### PR TITLE
Resolve wildcard dependency just like central package versions

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -432,7 +432,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_UpdatePackageReferenceVersions"
           Inputs="@(PackageReference)"
           Outputs="|%(Identity)|"
-          Condition="'$(UsingMicrosoftNETSdk)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true'"
+          Condition="'$(UsingMicrosoftNETSdk)' == 'true'"
           DependsOnTargets="RunResolvePackageDependencies"
           Returns="@(_CentrallyManagedDependency)">
 
@@ -442,19 +442,20 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_CandidatePackageIsImplicit>%(PackageReference.IsImplicitlyDefined)</_CandidatePackageIsImplicit>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_CandidatePackageVersion)' == '' and '$(_CandidatePackageIsImplicit)' != 'true'">
-      <_CentrallyManagedDependency Include="@(PackageDependencies)"
-                                   Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('$(_CandidatePackageId)/')) and 
-                                              $([MSBuild]::ValueOrDefault('%(ParentPackage)', '')) == ''" />
+    <ItemGroup Condition="$(_CandidatePackageIsImplicit) != 'true' and 
+                          ($(_CandidatePackageVersion) == '' or $(_CandidatePackageVersion.Contains('*')))">
+      <_ResolvedPackageDependency Include="@(PackageDependencies)"
+                                  Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('$(_CandidatePackageId)/')) and 
+                                             $([MSBuild]::ValueOrDefault('%(ParentPackage)', '')) == ''" />
     </ItemGroup>
 
-    <PropertyGroup Condition="'@(_CentrallyManagedDependency)' != ''">
-      <_CentrallyManagedDependency>%(_CentrallyManagedDependency.Identity)</_CentrallyManagedDependency>
-      <_CentrallyManagedVersion>$(_CentrallyManagedDependency.Replace('$(_CandidatePackageId)/', ''))</_CentrallyManagedVersion>
+    <PropertyGroup Condition="'@(_ResolvedPackageDependency)' != ''">
+      <_ResolvedPackageDependency>%(_ResolvedPackageDependency.Identity)</_ResolvedPackageDependency>
+      <_ResolvedPackageVersion>$(_ResolvedPackageDependency.Replace('$(_CandidatePackageId)/', ''))</_ResolvedPackageVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_CentrallyManagedVersion)' != ''">
-      <PackageReference Update="@(PackageReference)" Version="$(_CentrallyManagedVersion)" />
+    <ItemGroup Condition="'$(_ResolvedPackageVersion)' != ''">
+      <PackageReference Update="@(PackageReference)" Version="$(_ResolvedPackageVersion)" />
     </ItemGroup>
 
   </Target>

--- a/src/NuGetizer.Tests/given_packinference.cs
+++ b/src/NuGetizer.Tests/given_packinference.cs
@@ -628,5 +628,32 @@ namespace NuGetizer
             }));
         }
 
+        [Fact]
+        public void when_packing_dependencies_then_resolves_wildcard()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                	<PropertyGroup>
+                		<OutputType>Exe</OutputType>
+                		<TargetFramework>netstandard2.0</TargetFramework>
+                        <IsPackable>true</IsPackable>
+                        <LangVersion>Latest</LangVersion>
+                	</PropertyGroup>
+                
+                	<ItemGroup>
+                		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.*" />
+                	</ItemGroup>
+                </Project>
+                """, output: output);
+
+            result.AssertSuccess(output);
+
+            Assert.DoesNotContain(result.Items, item => item.Matches(new
+            {
+                PackFolder = "Dependency",
+                Version = "4.0.*",
+            }));
+        }
     }
 }


### PR DESCRIPTION
When dependency has a wildcard, we can use the exact same approach we use to resolve empty version in centrally managed package versions.

Fixes #64