### PR TITLE
Never infer implicit reference for existing direct reference

### DIFF
--- a/src/NuGetizer.Tasks/InferImplicitPackageReference.cs
+++ b/src/NuGetizer.Tasks/InferImplicitPackageReference.cs
@@ -53,6 +53,7 @@ namespace NuGetizer.Tasks
             }
 
             var inferred = new Dictionary<PackageIdentity, ITaskItem>();
+            var direct = new HashSet<string>(PackageReferences.Select(x => x.ItemSpec));
 
             foreach (var reference in PackageReferences)
             {
@@ -60,7 +61,7 @@ namespace NuGetizer.Tasks
                 var originalMetadata = (IDictionary<string, string>)reference.CloneCustomMetadata();
                 foreach (var dependency in FindDependencies(identity, packages))
                 {
-                    if (!inferred.ContainsKey(dependency))
+                    if (!direct.Contains(dependency.Id) && !inferred.ContainsKey(dependency))
                     {
                         var item = new TaskItem(dependency.Id);
                         foreach (var metadata in originalMetadata)

--- a/src/NuGetizer.Tests/InferImplicitPackageReferenceTests.cs
+++ b/src/NuGetizer.Tests/InferImplicitPackageReferenceTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Logging.StructuredLogger;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging.Signing;
+using NuGetizer.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Metadata = System.Collections.Generic.Dictionary<string, string>;
+
+namespace NuGetizer;
+
+public class InferImplicitPackageReferenceTests
+{
+    readonly ITestOutputHelper output;
+    readonly MockBuildEngine engine;
+
+    public InferImplicitPackageReferenceTests(ITestOutputHelper output)
+    {
+        this.output = output;
+        engine = new MockBuildEngine(output);
+    }
+
+    [Fact]
+    public void when_file_has_no_kind_then_logs_error_code()
+    {
+        var task = new InferImplicitPackageReference
+        {
+            BuildEngine = engine,
+            PackageReferences = new ITaskItem[]
+            {
+                new TaskItem("NuGetizer", new Metadata
+                {
+                    { "Version", "1.0.0" },
+                    { "PrivateAssets", "all" },
+                }),
+                new TaskItem("Devlooped.SponsorLink", new Metadata
+                {
+                    { "Version", "1.0.0" },
+                })
+            },
+            PackageDependencies = new ITaskItem[]
+            {
+                new TaskItem("NuGetizer", new Metadata
+                {
+                    { "ParentPackage", "" },
+                }),
+                new TaskItem("Devlooped.SponsorLink", new Metadata
+                {
+                    { "ParentPackage", "" },
+                }),
+                new TaskItem("NuGetizer/1.0.0", new Metadata
+                {
+                    { "ParentTarget", "netstandard2.0" },
+                    { "ParentPackage", "" },
+                }),
+                new TaskItem("Devlooped.SponsorLink/1.0.0", new Metadata
+                {
+                    { "ParentTarget", "netstandard2.0" },
+                    { "ParentPackage", "NuGetizer/1.0.0" },
+                })
+            }
+        };
+
+        Assert.True(task.Execute());
+        Assert.Empty(task.ImplicitPackageReferences);
+    }
+}


### PR DESCRIPTION
We should never traverse and infer implicit transitive dependencies for packages that are already directly referenced by the project.

This fixes the scenario where the project has a direct dependency to a package and another direct dependency has a transitive dependency to the same one. By inferring the latter as an implicit dependency, we overwrite the pack attributes of the former.