### PR TITLE
Make NuGetizer targets buildTransitive to fix SponsorLink

### DIFF
--- a/src/CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CodeAnalysis/CodeAnalysis.csproj
@@ -14,11 +14,14 @@
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.1.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Strings" Version="1.1.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.221-main" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="NuGetizer.CodeAnalysis.targets" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="NuGetizer.CodeAnalysis.targets" PackFolder="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgDevlooped_SponsorLink)\buildTransitive\Devlooped.SponsorLink.targets" 
+          PackFolder="buildTransitive" 
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
+++ b/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
@@ -18,8 +18,6 @@
 
     <CompilerVisibleProperty Include="Authors" />
     <CompilerVisibleProperty Include="AssemblyName" />
-
-    <SponsorablePackageId Include="NuGetizer" />
   </ItemGroup>
 
   <Target Name="_AddDescription" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
@@ -29,4 +27,13 @@
     </ItemGroup>
   </Target>
 
+  <ItemGroup Label="SponsorLink">
+    <SponsorablePackageId Include="NuGetizer" />
+  </ItemGroup>
+
+  <!-- This ensures devlooped targets are imported transitively even if we are a dev dependency 
+       and therefore don't propagate the SL dependency, which would otherwise cause a build error 
+       due to analyzers being forcedly transitive even if the reference is private assets/dev dep.
+  -->
+  <Import Project="Devlooped.SponsorLink.targets" Condition="$(SponsorLinkImported) != true"/>
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
@@ -19,7 +19,7 @@
     <Description>Simple, flexible and powerful NuGet packaging</Description>
 
     <DevelopmentDependency>true</DevelopmentDependency>
-    <PackFolder>build</PackFolder>
+    <PackFolder>buildTransitive</PackFolder>
 
     <PackOnBuild Condition="'$(PackOnBuild)' == '' And '$(Configuration)' == 'Release'">true</PackOnBuild>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">..\..\bin</PackageOutputPath>


### PR DESCRIPTION
For development-dependency packages, no assets flow across project references, including build targets and package dependencies. This is problematic for SponsorLink since it needs targets to properly surface build properties to the analyzer that performs the checks.

By making NuGetizer build targets transitive, we fix the project to project (P2P) scenario where one project installs NuGetizer and referencing projects start failing the SponsorLink check because the SL targets are missing. (since the package dependency on SL isn't surfaced in that case).

By also including the SL targets in our package and conditionally importing them if they haven't already been imported, we further remove the changes that the missing dependency causes failures.

This might not be the optimal way to solve this, but it's the only one that works consistently. This obviously causes P2P references to a project consuming NuGetizer to *also* become nugetized themselves. This should be a minor issue, however.