### PR TITLE
Never pack NuGetizer transitively

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -190,8 +190,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       _SetPackTargetFramework;
       InferPackageContents
     </GetPackageContentsDependsOn>
-
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- NuGetizer should never pack transitively (i.e. SponsorLink assets), even 
+         when PrivateAssets=all is used due to being a development dependency now. -->
+    <PackageReference Update="NuGetizer" PackTransitively="false" />    
+  </ItemGroup>
 
   <Target Name="_SetDefaultPackageReferencePack" Condition="'$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive'"
           BeforeTargets="InferPrimaryOutputDependencies;InferPackageContents">


### PR DESCRIPTION
This stops inference from collecting transitive dependency files from NuGetizer and packing them too alongisde the consuming project.

This is currently an issue since due to being a development dependency, NuGetizer will by default install with a `PrivateAssets=all` value, which for packing purposes means "pack everything this dependency brings, transitively, into this package output", since that's the most common scenario.

But for build-only packages like NuGetizer, it doesn't make sense. Especially for non-build transitive assets such as analyzer's localization files (i.e. SponsorLink in NuGetizer's case).

So we default this to the most obvious value now.