### PR TITLE
Ensure private assets always for NuGetizer

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -195,7 +195,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <ItemGroup>
     <!-- NuGetizer should never pack transitively (i.e. SponsorLink assets), even 
          when PrivateAssets=all is used due to being a development dependency now. -->
-    <PackageReference Update="NuGetizer" PackTransitively="false" />    
+    <PackageReference Update="NuGetizer" PackTransitively="false" />
   </ItemGroup>
 
   <Target Name="_SetDefaultPackageReferencePack" Condition="'$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive'"

--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -20,6 +20,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Adds CodeAnalysis props and items needed for diagnostics -->
   <Import Project="NuGetizer.CodeAnalysis.targets" />
 
+  <ItemGroup>
+    <!-- NuGetizer should *always* be a private asset. This avoids SL checks on P2P scenarios. -->
+    <PackageReference Update="NuGetizer" PrivateAssets="all" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Whether to infer package contents -->
     <EnablePackInference Condition="'$(EnablePackInference)' == ''">true</EnablePackInference>


### PR DESCRIPTION
Since analyzers are transitive by default (unless PrivateAssets=all in the PackageReference), we could have been inadvertently running SL checks via project-to-project (P2P) references and causing build errors since SL requires some compiler-visible properties surfaced via MSBuild that would otherwise not be available.

This can happen if you add a package reference manually and forget to set PrivateAssets=all. But NuGetizer is *always* intended to be private assets.

After some testing, it turns out that even if we set the PrivateAssets=all via targets provided by the package itself, we can prevent this abnormal (but perhaps easy to encounter?) situation from happening at all.

This is particularly necessary with the introduction of the SponsorLink checks, since those are analyzers too, and require compiler-visible properties to be surfaced.

By forcing PrivateAssets, we make sure SponsorLink analyzer never runs on P2P projects and only on the directly referencing one.