### PR TITLE
Revert changes to make build targets transitive

### DIFF
--- a/src/CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CodeAnalysis/CodeAnalysis.csproj
@@ -14,14 +14,11 @@
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.1.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Strings" Version="1.1.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.2" GeneratePathProperty="true" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="NuGetizer.CodeAnalysis.targets" PackFolder="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgDevlooped_SponsorLink)\buildTransitive\Devlooped.SponsorLink.targets" 
-          PackFolder="buildTransitive" 
-          CopyToOutputDirectory="PreserveNewest" />
+    <None Update="NuGetizer.CodeAnalysis.targets" PackFolder="build" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
+++ b/src/CodeAnalysis/NuGetizer.CodeAnalysis.targets
@@ -31,9 +31,4 @@
     <SponsorablePackageId Include="NuGetizer" />
   </ItemGroup>
 
-  <!-- This ensures devlooped targets are imported transitively even if we are a dev dependency 
-       and therefore don't propagate the SL dependency, which would otherwise cause a build error 
-       due to analyzers being forcedly transitive even if the reference is private assets/dev dep.
-  -->
-  <Import Project="Devlooped.SponsorLink.targets" Condition="$(SponsorLinkImported) != true"/>
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
@@ -19,7 +19,7 @@
     <Description>Simple, flexible and powerful NuGet packaging</Description>
 
     <DevelopmentDependency>true</DevelopmentDependency>
-    <PackFolder>buildTransitive</PackFolder>
+    <PackFolder>build</PackFolder>
 
     <PackOnBuild Condition="'$(PackOnBuild)' == '' And '$(Configuration)' == 'Release'">true</PackOnBuild>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">..\..\bin</PackageOutputPath>


### PR DESCRIPTION
This is no longer needed now that we update NuGetizer package reference to always be PrivateAssets=all, to account for users not doing it (misconfig issue).

This also fixes the issue with multi-targeting projects referencing nugetizer now since we had the wrong path for importing targets in that case.