### PR TITLE
NuGetizer should always be Pack=false

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <ItemGroup>
     <!-- NuGetizer should *always* be a private asset. This avoids SL checks on P2P scenarios. -->
-    <PackageReference Update="NuGetizer" PrivateAssets="all" />
+    <PackageReference Update="NuGetizer" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This prevents transitive packing of SponsorLink analyzer localization resources, for example.