### PR TITLE
Clean package cache only after packing

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Cleanup.targets
@@ -37,7 +37,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!-- Clears nuget cache for the current project package id -->
-  <Target Name="CleanCachedPackageId" AfterTargets="Build;Pack">
+  <Target Name="CleanCachedPackageId" AfterTargets="Pack">
     <PropertyGroup>
       <PackageFolder>$(NuGetCache)\$(PackageId.ToLowerInvariant())</PackageFolder>
     </PropertyGroup>
@@ -49,7 +49,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <Target Name="CleanHttpNuGetCache"
           Condition="'$(CleanHttpNuGetCacheOnPack)' == 'true' and Exists('$(HttpNuGetCache)')"
-          AfterTargets="Build;Pack">
+          AfterTargets="Pack">
     <Message Text="Cleaning $(HttpNuGetCache)" />
     <Exec Command='rd "$(HttpNuGetCache)" /q /s' Condition="'$(OS)' == 'Windows_NT'" />
     <Exec Command='rm -rf "$(HttpNuGetCache)"' Condition="'$(OS)' != 'Windows_NT'" />


### PR DESCRIPTION
Since non-packaging projects might be built multiple times without producing packages, cleaning after every build is not only wasteful (in terms of processing/time) but can also break other currently opened solutions and require force-restoring.

Fixes #369