### PR TITLE
Make sure we can explicitly pack a privateassets/development dependency

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -401,8 +401,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        '$(PackAsPublish)' != 'true' and 
                                        '%(PackageReference.Identity)' != 'NuGetizer' and
                                        '%(PackageReference.Identity)' != 'NETStandard.Library' and 
-                                       '%(PackageReference.PrivateAssets)' != 'all' and
-                                       '%(PackageReference.Pack)' != 'false'">
+                                       '%(PackageReference.Pack)' != 'false' and 
+                                       ('%(PackageReference.PrivateAssets)' != 'all' or '%(PackageReference.Pack)' == 'true')">
         <PackFolder>Dependency</PackFolder>
         <!--<FrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == 'true'">true</FrameworkSpecific>-->
       </_InferredPackageFile>

--- a/src/NuGetizer.Tests/InlineProjectTests.cs
+++ b/src/NuGetizer.Tests/InlineProjectTests.cs
@@ -1053,5 +1053,32 @@ namespace NuGetizer
                 PackagePath = "assets/screen.png",
             }));
         }
+
+        [Fact]
+        public void when_dependency_is_development_dependency_then_can_explicitly_pack_it()
+        {
+            var result = Builder.BuildProject(
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="ThisAssembly.Constants" Version="1.2.14" Pack="true" TargetFramework="netstandard2.0" />
+                  </ItemGroup>
+                </Project>  
+                """
+                , "GetPackageContents", output);
+
+            result.AssertSuccess(output);
+
+            Assert.Contains(result.Items, item => item.Matches(new
+            {
+                Identity = "ThisAssembly.Constants",
+                PackFolder = "Dependency",
+            }));
+        }
+
     }
 }


### PR DESCRIPTION
As a package author, you might consume a development dependency for your own authoring, but also might want to take a dependency on it in your package. GitInfo is an example.

We want to make sure we honor explicit Pack=true even if a package has PrivateAssets=all (which has different use cases too).

Fixes #281 