### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Shared.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Shared.targets
@@ -18,7 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!-- Adds compatibility targets with Pack SDK -->
   <Import Project="NuGetizer.Compatibility.props" />
   <!-- Adds CodeAnalysis props and items needed for diagnostics -->
-  <Import Project="NuGetizer.CodeAnalysis.targets" />
+  <!--<Import Project="NuGetizer.CodeAnalysis.targets" />-->
 
   <ItemGroup>
     <!-- NuGetizer should *always* be a private asset. This avoids SL checks on P2P scenarios. -->

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="NuGet.Packaging" Version="6.3.0" PrivateAssets="all" />
     <PackageReference Include="NuGet.ProjectManagement" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly.Project" Version="1.3.0" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly.Strings" Version="1.3.0" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="1.4.0" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Strings" Version="1.4.0" PrivateAssets="all" />
     <PackageReference Include="Minimatch" Version="2.0.0" PrivateAssets="all" />
   </ItemGroup>
 
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" />
+    <!--<ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" />-->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink