### PR TITLE
Fix copy error in inference targets for package icon

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -290,7 +290,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_ExistingReadme Include="@(Content -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))" Condition="'@(_ExistingReadme)' == ''" />
       <_ExistingReadme Include="$(MSBuildProjectDirectory)\$(PackageReadmeFilename)$(PackageReadmeExtension)" Condition="'@(_ExistingReadme)' == '' and Exists('$(MSBuildProjectDirectory)\$(PackageReadmeFilename)$(PackageReadmeExtension)')" />
 
-      <InferenceCandidate Include="@(_ExistingReadme)"
+      <InferenceCandidate Include="@(_ExistingReadme -> Distinct())"
                           PackagePath="%(Filename)%(Extension)"
                           Condition="'%(Extension)' == '$(PackageReadmeExtension)'" />
     </ItemGroup>
@@ -306,15 +306,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Even if all these conditions are false, the user can still explicitly pack the icon file, of course -->
     <ItemGroup Label="Icon" Condition="'$(PackageIcon)' != ''">
-      <_ExistingIcon Include="@(None -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))" />
+      <_ExistingIcon Include="@(None -> WithMetadataValue('Filename', '$(PackageIconFilename)'))" />
+      <_ExistingIcon Include="@(Content -> WithMetadataValue('Filename', '$(PackageIconFilename)'))" Condition="'@(_ExistingIcon)' == ''" />
+      <_ExistingIcon Include="$(MSBuildProjectDirectory)\$(PackageIconFilename)$(PackageIconExtension)" Condition="'@(_ExistingIcon)' == '' and Exists('$(MSBuildProjectDirectory)\$(PackageIconFilename)$(PackageIconExtension)')" />
 
-      <_ExistingReadme Include="@(None -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))" />
-      <_ExistingReadme Include="@(Content -> WithMetadataValue('Filename', '$(PackageReadmeFilename)'))" Condition="'@(_ExistingReadme)' == ''" />
-      <_ExistingReadme Include="$(MSBuildProjectDirectory)\$(PackageReadmeFilename)$(PackageReadmeExtension)" Condition="'@(_ExistingReadme)' == '' and Exists('$(MSBuildProjectDirectory)\$(PackageReadmeFilename)$(PackageReadmeExtension)')" />
-
-      <InferenceCandidate Include="@(_ExistingReadme)"
+      <InferenceCandidate Include="@(_ExistingIcon -> Distinct())"
                           PackagePath="%(Filename)%(Extension)"
-                          Condition="'%(Extension)' == '$(PackageReadmeExtension)'" />
+                          Condition="'%(Extension)' == '$(PackageIconExtension)'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We were duplicating the logic for package readme files instead of package icon due to duplicated code.

Fixes #436