### PR TITLE
Rename BuildOutputFrameworkSpecific > PackFrameworkSpecific for consistency

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Authoring.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Authoring.props
@@ -25,7 +25,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PackBuildOutput>false</PackBuildOutput>
     <PackFolder>Ignore</PackFolder>
-    <BuildOutputFrameworkSpecific>false</BuildOutputFrameworkSpecific>
+    <PackFrameworkSpecific>false</PackFrameworkSpecific>
   </PropertyGroup>
 
   <!--

--- a/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
+++ b/src/NuGetizer.Tasks/NuGetizer.Compatibility.props
@@ -44,7 +44,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackFrameworkReferences Condition="'$(PackFrameworkReferences)' == '' and '$(IncludeFrameworkReferencesInPackage)' != ''">$(IncludeFrameworkReferencesInPackage)</PackFrameworkReferences>
     <PackProjectReferences Condition="'$(PackProjectReferences)' == '' and '$(PackProjectReference)' != ''">true</PackProjectReferences>
 
-    <DevelopmentDependency Condition="'$(IsDevelopmentDependency)' != ''">$(IsDevelopmentDependency)</DevelopmentDependency>
+    <DevelopmentDependency Condition="'$(DevelopmentDependency)' == '' and '$(IsDevelopmentDependency)' != ''">$(IsDevelopmentDependency)</DevelopmentDependency>
+
+    <PackFrameworkSpecific Condition="'$(PackFrameworkSpecific)' == '' and '$(BuildOutputFrameworkSpecific)' != ''">$(BuildOutputFrameworkSpecific)</PackFrameworkSpecific>
   </PropertyGroup>
 
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -240,7 +240,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup Condition="'$(PackInferenceIdentity)' == 'None' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive')">
       <None Update="@(None)" Condition="'%(None.PackFolder)' == ''" PackFolder="$(PackFolder)" />
-      <None Update="@(None)" Condition="'%(None.FrameworkSpecific)' == ''" FrameworkSpecific="$(BuildOutputFrameworkSpecific)" />
+      <None Update="@(None)" Condition="'%(None.FrameworkSpecific)' == ''" FrameworkSpecific="$(PackFrameworkSpecific)" />
     </ItemGroup>
 
     <!-- If we have an exclude wildcard to evaluate, do so and keep only non-matching items -->
@@ -362,13 +362,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      @(DocumentationProjectOutputGroupOutput -> '%(FinalOutputPath)');
                                      @(_SatelliteDllsProjectOutputGroupOutput -> '%(FinalOutputPath)')">
         <PackFolder>$(PackFolder)</PackFolder>
-        <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <FrameworkSpecific>$(PackFrameworkSpecific)</FrameworkSpecific>
       </_InferredProjectOutput>
 
       <_InferredProjectOutput Include="@(DebugSymbolsProjectOutputGroupOutput -> '%(FinalOutputPath)')"
                               Condition="'$(PackSymbols)' != 'false'">
         <PackFolder>$(PackFolder)</PackFolder>
-        <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <FrameworkSpecific>$(PackFrameworkSpecific)</FrameworkSpecific>
       </_InferredProjectOutput>
 
       <_InferredPackageFile Include="@(_InferredProjectOutput -> Distinct())" />
@@ -379,7 +379,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_InferredPackageFile Include="@(ResourceCopyLocalItems)"
                             PackFolder="$(PackFolder)"
                             TargetPath="%(ResourceCopyLocalItems.DestinationSubPath)"
-                            FrameworkSpecific="$(BuildOutputFrameworkSpecific)"
+                            FrameworkSpecific="$(PackFrameworkSpecific)"
                             Condition="$(PrivatePackageReferenceIds.Contains(';%(ResourceCopyLocalItems.NuGetPackageId);'))" />
     </ItemGroup>
 
@@ -388,7 +388,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_InferredPackageFile Include="@(_InferredPublishItem -> '%(FullPath)')">
         <PackFolder>$(PackFolder)</PackFolder>
         <FrameworkSpecific>false</FrameworkSpecific>
-        <!-- NOTE: we don't set `BuildOutputFrameworkSpecific` since we're not packing the build output
+        <!-- NOTE: we don't set `PackFrameworkSpecific` since we're not packing the build output
              but rather the *publish* output. Users could change that by setting a TF-specific PackFolder -->
       </_InferredPackageFile>
     </ItemGroup>
@@ -402,7 +402,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                        '%(PackageReference.Pack)' != 'false' and 
                                        ('%(PackageReference.PrivateAssets)' != 'all' or '%(PackageReference.Pack)' == 'true')">
         <PackFolder>Dependency</PackFolder>
-        <!--<FrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == 'true'">true</FrameworkSpecific>-->
+        <!--<FrameworkSpecific Condition="'$(PackFrameworkSpecific)' == 'true'">true</FrameworkSpecific>-->
       </_InferredPackageFile>
 
       <!-- We can't use %(FrameworkFile)==true because it's not defined for raw file references and 
@@ -427,7 +427,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
         <OriginalTargetFramework>$(PackTargetFramework)</OriginalTargetFramework>
-        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(PackFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
   </Target>
@@ -544,7 +544,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(_ShouldPack)' != 'false' and '$(_PrivateAssets)' == 'all'">
       <_InferredPackageFile Include="@(_PrimaryOutputFinalFile)">
         <PackFolder>$(PackFolder)</PackFolder>
-        <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <FrameworkSpecific>$(PackFrameworkSpecific)</FrameworkSpecific>
       </_InferredPackageFile>
     </ItemGroup>
 
@@ -555,7 +555,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_InferredPackageFile Include="@(_PrimaryOutputFinalFile)"
                             Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(_PrimaryOutputFinalFile.FullPath)', '$(_ShouldIncludeAssetsRegex)', 'RegexOptions.IgnoreCase')) == 'true'">
         <PackFolder>$(PackFolder)</PackFolder>
-        <FrameworkSpecific>$(BuildOutputFrameworkSpecific)</FrameworkSpecific>
+        <FrameworkSpecific>$(PackFrameworkSpecific)</FrameworkSpecific>
       </_InferredPackageFile>
     </ItemGroup>
   </Target>

--- a/src/NuGetizer.Tasks/NuGetizer.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.targets
@@ -9,7 +9,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved. 
 ***********************************************************************************************
 -->
-<Project InitialTargets="_SetPropertiesFromCapabilities;_SetBuildOutputFrameworkSpecific" TreatAsLocalProperty="PackFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project InitialTargets="_SetPropertiesFromCapabilities;_SetPackFrameworkSpecific" TreatAsLocalProperty="PackFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="NuGetizer.Tasks.AssignPackagePath" AssemblyFile="NuGetizer.Tasks.dll" />
   <UsingTask TaskName="NuGetizer.Tasks.WriteItemsToFile" AssemblyFile="NuGetizer.Tasks.dll" />
 
@@ -66,7 +66,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <PackageFile>
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
         <Platform Condition="'%(PackageFile.Platform)' == ''">$(Platform)</Platform>
-        <DefaultTargetFramework Condition="'%(PackageFile.DefaultTargetFramework)' == '' and ('$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true')">$(PackTargetFramework)</DefaultTargetFramework>
+        <DefaultTargetFramework Condition="'%(PackageFile.DefaultTargetFramework)' == '' and ('$(IsPackagingProject)' != 'true' or '$(PackFrameworkSpecific)' == 'true')">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
 
@@ -128,7 +128,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackFolder>Metadata</PackFolder>
         <PackageId>$(PackageId)</PackageId>
         <Platform>$(Platform)</Platform>
-        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true' or '$(PackFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
       </PackageFile>
     </ItemGroup>
   </Target>
@@ -179,7 +179,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                                '%(_ReferencedPackageContent.PackFolder)' == 'Metadata'">
         <!-- For consistency, annotate like the rest -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
-        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true'  or '$(BuildOutputFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
+        <DefaultTargetFramework Condition="'$(IsPackagingProject)' != 'true'  or '$(PackFrameworkSpecific)' == 'true'">$(PackTargetFramework)</DefaultTargetFramework>
         <PackFolder>Dependency</PackFolder>
       </_ReferencedPackageDependency>
       <!-- Remove the referenced package actual contents if it provides a manifest, since it will be a dependency in that case. -->
@@ -198,7 +198,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- We don't retarget referenced content for packaging projects that aren't framework specific, and
          never retarget content that already has a PackageId. -->
-    <ItemGroup Condition="'$(IsPackagingProject)' != 'true' or '$(BuildOutputFrameworkSpecific)' == 'true'">
+    <ItemGroup Condition="'$(IsPackagingProject)' != 'true' or '$(PackFrameworkSpecific)' == 'true'">
       <_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
         <!-- Assign current package id if appropriate -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
@@ -220,7 +220,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Otherwise, assign target paths based on the original TFM -->
-    <ItemGroup Condition="'$(IsPackagingProject)' == 'true' and '$(BuildOutputFrameworkSpecific)' != 'true'">
+    <ItemGroup Condition="'$(IsPackagingProject)' == 'true' and '$(PackFrameworkSpecific)' != 'true'">
       <_ReferencedPackageContentWithOriginalValues Condition="'%(_ReferencedPackageContentWithOriginalValues.PackageId)' == ''">
         <!-- Assign current package id if appropriate -->
         <PackageId Condition="'$(IsPackable)' == 'true'">$(PackageId)</PackageId>
@@ -277,8 +277,8 @@ Copyright (c) .NET Foundation. All rights reserved.
         <AdditionalProperties Condition="'$(_PrivateAssets)' == 'all'">IsPackable=false;%(_MSBuildProjectReferenceExistent.AdditionalProperties)</AdditionalProperties>
         <!-- If the project reference itself declares a PackFolder, use that instead of the calling project's -->
         <SetPackFolder Condition="'%(PackFolder)' != ''">PackFolder=%(PackFolder)</SetPackFolder>
-        <!-- Otherwise, set both PackFolder and BuildOutputFrameworkSpecific so it will match the caller's -->
-        <SetPackFolder Condition="'%(PackFolder)' == '' and '$(_PrivateAssets)' == 'all' and '$(PackFolder)' != '' and '$(PackFolder)' != 'Ignore'">PackFolder=$(PackFolder);BuildOutputFrameworkSpecific=$(BuildOutputFrameworkSpecific)</SetPackFolder>
+        <!-- Otherwise, set both PackFolder and PackFrameworkSpecific so it will match the caller's -->
+        <SetPackFolder Condition="'%(PackFolder)' == '' and '$(_PrivateAssets)' == 'all' and '$(PackFolder)' != '' and '$(PackFolder)' != 'Ignore'">PackFolder=$(PackFolder);PackFrameworkSpecific=$(PackFrameworkSpecific)</SetPackFolder>
       </_NuGetizedProjectReference>
     </ItemGroup>
 
@@ -298,14 +298,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetBuildOutputFrameworkSpecific" Condition="'$(BuildOutputFrameworkSpecific)' == ''">
+  <Target Name="_SetPackFrameworkSpecific" Condition="'$(PackFrameworkSpecific)' == ''">
     <!-- Determine whether primary output is framework specific  -->
     <ItemGroup>
-      <_BuildOutputFrameworkSpecific Include="@(PackFolderKind -> '%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(PackFolder)'" />
+      <_PackFrameworkSpecific Include="@(PackFolderKind -> '%(FrameworkSpecific)')" Condition="'%(Identity)' == '$(PackFolder)'" />
     </ItemGroup>
     <PropertyGroup>
-      <BuildOutputFrameworkSpecific>@(_BuildOutputFrameworkSpecific)</BuildOutputFrameworkSpecific>
-      <BuildOutputFrameworkSpecific Condition="'$(BuildOutputFrameworkSpecific)' == ''">false</BuildOutputFrameworkSpecific>
+      <PackFrameworkSpecific>@(_PackFrameworkSpecific)</PackFrameworkSpecific>
+      <PackFrameworkSpecific Condition="'$(PackFrameworkSpecific)' == ''">false</PackFrameworkSpecific>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGetizer.Tests/given_a_packaging_project.cs
+++ b/src/NuGetizer.Tests/given_a_packaging_project.cs
@@ -182,13 +182,13 @@ namespace NuGetizer
     <PackageId>Packer</PackageId>
     <TargetFramework>net6.0</TargetFramework>
     <PackFolder>build</PackFolder>
-    <BuildOutputFrameworkSpecific>true</BuildOutputFrameworkSpecific>
+    <PackFrameworkSpecific>true</PackFrameworkSpecific>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include='Tasks.csproj' PrivateAssets='all' />
     <!-- NOTE: for other stuff, we can put it in the same folders as the build output by 
          specifying PackFolder and FrameworkSpecific to match the project's. -->
-    <None Include='readme.md' PackFolder='$(PackFolder)' FrameworkSpecific='$(BuildOutputFrameworkSpecific)' />
+    <None Include='readme.md' PackFolder='$(PackFolder)' FrameworkSpecific='$(PackFrameworkSpecific)' />
   </ItemGroup>
 </Project>",
                 "GetPackageContents", output,


### PR DESCRIPTION
Since a packaging project (for example) doesn't actually contain build artifacts but can still default its root content to a framework-specific folder, we should instead adopt the uniform `Pack*` prefix we now use everywhere.

Fixes #438