### PR TITLE
Remove workload restore to speed up build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
         working-directory: src/NuGetizer.Tests
         run: |
           dotnet restore Scenarios/given_a_packaging_project/a.nuproj
-          dotnet workload restore
-          dotnet workload restore Scenarios/given_multitargeting_libraries/uilibrary.csproj
           msbuild -r
 
       - name: 🐛 logs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
         working-directory: src/NuGetizer.Tests
         run: |
           dotnet restore Scenarios/given_a_packaging_project/a.nuproj
-          dotnet workload restore
           msbuild -r
 
       - name: 🐛 logs


### PR DESCRIPTION
Since tests aren't actually building stuff, the workloads don't really need to be installed.