### PR TITLE
Additional fix for --no-build in pack with transitive references

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -574,6 +574,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 						$(_AllProjectCapabilities.Contains('WinRTReferences')) or
 						$(_AllProjectCapabilities.Contains('SDKReferences'))">true</_SupportsReferences>
 
+      <!-- Very constrained scenario for CLI pack with dotnet pack -no-build, which otherwise triggers 
+           transitive project references to be built when that's not what the user wants. -->
+      <DisableTransitiveProjectReferences Condition="'$(_SupportsReferences)' == 'true' and
+                                                     '$(_IsPacking)' == 'true' and 
+                                                     '$(NoBuild)' == 'true' and 
+                                                     '$(BuildingInsideVisualStudio)' != 'true' and 
+                                                     '$(DesignTimeBuild)' != 'true'" >true</DisableTransitiveProjectReferences>
+
       <InferPackageContentsDependsOn Condition="'$(_SupportsReferences)' == 'true'">
         ResolveReferences;
         _UpdatePackageReferenceVersions;

--- a/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project1.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project1.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>Foo</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Project2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project2.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project2.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Project3.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project3.csproj
+++ b/src/NuGetizer.Tests/Scenarios/given_transitive_projects/Project3.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Scenario.props, $(MSBuildThisFileDirectory)))" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGetizer" Version="1.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGetizer.Tests/given_transitive_projects.cs
+++ b/src/NuGetizer.Tests/given_transitive_projects.cs
@@ -1,0 +1,53 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetizer
+{
+    public class given_transitive_projects
+    {
+        readonly ITestOutputHelper output;
+
+        public given_transitive_projects(ITestOutputHelper output)
+        {
+            this.output = output;
+            using var disable = OpenBuildLogAttribute.Disable();
+
+            Builder.BuildScenario(nameof(given_transitive_projects), target: "Restore", projectName: "Project1")
+                .AssertSuccess(output);
+
+            Builder.BuildScenario(nameof(given_transitive_projects), target: "Build", projectName: "Project1")
+                .AssertSuccess(output);
+        }
+
+        [Fact]
+        public void when_pack_no_build_then_succeeds()
+        {
+            var result = Builder.BuildScenario(nameof(given_transitive_projects),
+                projectName: "Project1",
+                // These are the properties passed by dotnet pack --no-build
+                properties: new { NoBuild = "true", _IsPacking = "true" },
+                target: "GetPackageContents,Pack");
+
+            result.AssertSuccess(output);
+
+            Assert.True(result.BuildResult.HasResultsForTarget("GetPackageContents"));
+
+            var items = result.BuildResult.ResultsByTarget["GetPackageContents"];
+
+            Assert.Contains(items.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net8.0/Project1.dll"
+            }));
+
+            Assert.Contains(items.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net8.0/Project2.dll"
+            }));
+
+            Assert.Contains(items.Items, item => item.Matches(new
+            {
+                PackagePath = "lib/net8.0/Project3.dll"
+            }));
+        }
+    }
+}


### PR DESCRIPTION
Turns out that the .NET SDK lifts transitive project references as direct references (without any additional metadata), and this causes the second-level dependency from being built unexpectedly (see https://github.com/dotnet/sdk/pull/478 and https://github.com/dotnet/project-system/issues/199).

Since we don't want to disrupt the IDE (BuildingInsideVisualStudio) and we only want to fix this for the very specific case of running from the CLI `dotnet pack --no-build`, we make the fix very constrained for that scenario. We check for `NoBuild` but ALSO for `_IsPacking`, which is passed by the `dotnet pack` command.

This ensures minimal impact in all other scenarios, since we're essentially turning off a built-in behavior in the SDK that has explicit side-effects (by design and desirable) and we should preserve.

#Fixes 501