### PR TITLE
Fix issue with localized resources when packing tools

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.Inference.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Inference.targets
@@ -276,7 +276,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackagePathHasFilename Condition="$([MSBuild]::ValueOrDefault('%(PackagePath)', '').EndsWith('%(PackageFile)'))"></PackagePathHasFilename>
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Condition="'%(PackagePathHasFilename)' == 'false'">
-        <PackagePath>$([MSBuild]::ValueOrDefault('%(PackagePath)', '').TrimEnd('/'))/%(PackageFile)</PackagePath>
+        <PackagePath>$([MSBuild]::ValueOrDefault('%(PackagePath)', '').TrimEnd('/'))/%(RecursiveDir)%(PackageFile)</PackagePath>
       </TfmSpecificPackageFile>
       <None Include="@(TfmSpecificPackageFile)" />
 

--- a/src/NuGetizer.Tests/given_a_tool_project.cs
+++ b/src/NuGetizer.Tests/given_a_tool_project.cs
@@ -91,6 +91,27 @@ namespace NuGetizer
         }
 
         [Fact]
+        public void when_pack_as_tool_with_localized_resources_then_packs_dotnet_tool_runtime_assets()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <AssemblyName>MyTool</AssemblyName>
+    <PackageId>MyTool</PackageId>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackFolder>tools</PackFolder>
+    <PackAsTool>true</PackAsTool>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include='Spectre.Console.Cli' Version='0.51.1' />
+  </ItemGroup>    
+</Project>",
+                "Pack", output);
+
+            result.AssertSuccess(output);
+        }
+
+        [Fact]
         public void when_pack_folder_tool_but_no_pack_as_tool_then_packs_dependencies_normally()
         {
             var result = Builder.BuildProject(@"


### PR DESCRIPTION
Fix issue with localized resources when packing tools

We were missing the %(RecursiveDir) value which caused localized resources to end up as duplicate assets in the package, causing the pack to fail.