### PR TITLE
Avoid duplicate NuGet pack targets import

### DIFF
--- a/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.PackageMetadata.targets
@@ -12,6 +12,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Hidden">
+    <!-- If this file is the configured SDK pack targets import and it was imported manually
+         first, prevent Microsoft.NET.Sdk\Sdk.targets from importing the same file again. -->
+    <ImportNuGetBuildTasksPackTargetsFromSdk
+        Condition="'$(NuGetBuildTasksPackTargets)' != '' and
+                   '$([System.IO.Path]::GetFullPath(`$(NuGetBuildTasksPackTargets)`))' == '$(MSBuildThisFileFullPath)'">false</ImportNuGetBuildTasksPackTargetsFromSdk>
+
     <!-- Matches the SDK Pack default when set to true. -->
     <PackageId Condition="'$(IsPackable)' == 'true' and '$(PackageId)' == ''">$(AssemblyName)</PackageId>
     <PackageId Condition="'$(IsPackable)' == 'true' and '$(PackageId)' == ''">$(MSBuildProjectName)</PackageId>

--- a/src/NuGetizer.Tests/given_packinference.cs
+++ b/src/NuGetizer.Tests/given_packinference.cs
@@ -12,6 +12,29 @@ namespace NuGetizer
         public given_packinference(ITestOutputHelper output) => this.output = output;
 
         [Fact]
+        public void when_pack_metadata_is_imported_from_directory_targets_then_does_not_warn_on_duplicate_import()
+        {
+            var result = Builder.BuildProject(@"
+<Project Sdk='Microsoft.NET.Sdk'>
+  <PropertyGroup>
+    <PackageId>Library</PackageId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>",
+                "GetPackageContents", output, null,
+                ("Directory.Build.targets", @"
+<Project>
+  <Import Project='$(NuGetTargetsPath)\NuGetizer.PackageMetadata.targets'
+          Condition=""Exists('$(NuGetTargetsPath)\NuGetizer.PackageMetadata.targets')"" />
+</Project>"));
+
+            result.AssertSuccess(output);
+            Assert.DoesNotContain(result.Logger.Warnings, warning =>
+                warning.Code == "MSB4011" &&
+                warning.Message.Contains("NuGetizer.PackageMetadata.targets"));
+        }
+
+        [Fact]
         public void when_none_has_PackagePath_then_packs()
         {
             var result = Builder.BuildProject(@"

--- a/src/NuGetizer.Tests/given_packinference.cs
+++ b/src/NuGetizer.Tests/given_packinference.cs
@@ -20,9 +20,10 @@ namespace NuGetizer
     <PackageId>Library</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <Import Project='manual-import.targets' Condition=""Exists('manual-import.targets')"" />
 </Project>",
                 "GetPackageContents", output, null,
-                ("Directory.Build.targets", @"
+                ("manual-import.targets", @"
 <Project>
   <Import Project='$(NuGetTargetsPath)\NuGetizer.PackageMetadata.targets'
           Condition=""Exists('$(NuGetTargetsPath)\NuGetizer.PackageMetadata.targets')"" />


### PR DESCRIPTION
Make NuGetizer.PackageMetadata.targets stop the SDK from importing the same file twice when it is already configured as NuGetBuildTasksPackTargets, which avoids the MSB4011 warning in Directory.Build.targets workaround scenarios.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>