### PR TITLE
fix: ensure NuGetizer.Tasks self-pack emits build/ MSBuild assets

### DIFF
--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -9,6 +9,10 @@
   <Import Project="$(MSBuildThisFileDirectory)NuGetizer.Tasks\$(OutputPath)NuGetizer.targets"
           Condition="($(IsPackable) == 'true' OR $(PackFolder) != '') AND $(NuGetize) == 'true'" />
 
+  <!-- Imported last so it overrides SDK Pack's Pack target for NuGetizer.Tasks self-pack. -->
+  <Import Project="$(MSBuildThisFileDirectory)NuGetizer.Tasks\NuGetizer.Tasks.Pack.targets"
+          Condition="'$(MSBuildProjectName)' == 'NuGetizer.Tasks' and '$(NuGetize)' != 'true'" />
+
   <PropertyGroup>
     <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.Pack.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.Pack.targets
@@ -1,8 +1,10 @@
 <Project>
 
-  <!-- GeneratePackageOnBuild=false is used by VS when right-click Pack is used :) -->
-  <Target Name="Pack" Condition="'$(GeneratePackageOnBuild)' == 'false' AND '$(NuGetize)' != 'true'" Returns="@(PackOutput)">
-    <!-- Typically called in the IDE when we run Pack context menu. -->
+  <!--
+    NuGetizer.Tasks must always pack via NuGetizer (NuGetize=true), not SDK Pack.
+    VS right-click Pack sets GeneratePackageOnBuild=false; dotnet pack does not set NuGetize.
+  -->
+  <Target Name="Pack" Condition="'$(NuGetize)' != 'true'" Returns="@(PackOutput)">
     <MSBuild Projects="$(MSBuildProjectFullPath)" UnloadProjectsOnCompletion="true" UseResultsCache="false"
              Properties="NuGetize=true" Targets="Pack">
       <Output TaskParameter="TargetOutputs" ItemName="PackOutput"/>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
@@ -60,7 +60,6 @@
     <EmbeddedResource Update="Resources.resx" Generator="" />
   </ItemGroup>
   
-  <Import Project="NuGetizer.Tasks.Pack.targets" Condition="'$(GeneratePackageOnBuild)' == 'false' AND '$(NuGetize)' != 'true'" />
   <Import Project="NuGetizer.Tasks.targets" />
   <Import Project="..\ILRepack.targets" />
 </Project>

--- a/src/NuGetizer.Tests/given_nugetizer_self_pack.cs
+++ b/src/NuGetizer.Tests/given_nugetizer_self_pack.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using NuGetizer.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetizer
+{
+    /// <summary>
+    /// Regression tests for NuGetizer.Tasks self-packaging (dogfooding).
+    /// </summary>
+    public class given_nugetizer_self_pack
+    {
+        readonly ITestOutputHelper output;
+
+        public given_nugetizer_self_pack(ITestOutputHelper output) => this.output = output;
+
+        [RuntimeFact("Windows")]
+        public void when_packing_without_nugetize_property_then_build_folder_contains_msbuild_assets()
+        {
+            var project = Path.GetFullPath(Path.Combine(
+                ThisAssembly.Project.MSBuildProjectDirectory,
+                "..",
+                "NuGetizer.Tasks",
+                "NuGetizer.Tasks.csproj"));
+
+            var properties = new Dictionary<string, string>
+            {
+                ["Configuration"] = "Release",
+            };
+
+            var logger = new TestOutputLogger(output);
+            ILogger[] loggers = { logger };
+
+            AssertTargetSuccess(Builder.Build(project, "Restore", properties, loggers), "Restore");
+            AssertTargetSuccess(Builder.Build(project, "Build", properties, loggers), "Build");
+
+            var packResult = Builder.Build(project, "Pack,GetPackageTargetPath", properties, loggers);
+
+            AssertTargetSuccess(packResult, "GetPackageTargetPath");
+
+            var packagePath = packResult["GetPackageTargetPath"].Items
+                .Select(i => i.GetMetadata("FullPath"))
+                .FirstOrDefault(path => path.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase));
+
+            Assert.False(string.IsNullOrEmpty(packagePath));
+            Assert.True(File.Exists(packagePath), $"Package not found at {packagePath}");
+
+            using var package = ZipFile.OpenRead(packagePath);
+            var entries = package.Entries.Select(e => e.FullName.Replace('\\', '/')).ToArray();
+
+            Assert.Contains("build/NuGetizer.props", entries);
+            Assert.Contains("build/NuGetizer.Shared.targets", entries);
+            Assert.Contains("buildMultiTargeting/NuGetizer.props", entries);
+            Assert.DoesNotContain("content/NuGetizer.props", entries);
+        }
+
+        void AssertTargetSuccess(BuildResult result, string target)
+        {
+            if (!result.ResultsByTarget.TryGetValue(target, out var targetResult))
+            {
+                output.WriteLine(string.Join("\n", result.ResultsByTarget.Keys));
+                Assert.Fail($"Build results do not contain output for target {target}.");
+            }
+
+            if (targetResult.ResultCode != TargetResultCode.Success)
+                Assert.Fail($"Target {target} failed: {targetResult.Exception?.Message}");
+
+            Assert.Equal(TargetResultCode.Success, targetResult.ResultCode);
+        }
+    }
+}


### PR DESCRIPTION
NuGetizer 1.4.8 shipped a broken nupkg layout: `dotnet pack` used SDK Pack instead of NuGetizer pack, so props/targets landed in `content/` and `contentFiles/` while `buildMultiTargeting/` still imported `..\build\NuGetizer.props`. Multi-targeting consumers then failed with MSB4019 because `build/` was missing.

Redirect all NuGetizer.Tasks Pack invocations to NuGetize=true, not only VS right-click pack (`GeneratePackageOnBuild=false`). Import `NuGetizer.Tasks.Pack.targets` from `Directory.targets` after SDK Pack so the redirect wins over `NuGet.Build.Tasks.Pack.targets`. Remove the csproj import, which ran too early and was overridden by Sdk.targets.

Add a regression test that packs NuGetizer.Tasks without `/p:NuGetize=true` and asserts the nupkg contains `build/NuGetizer.props`, `build/NuGetizer.Shared.targets`, and `buildMultiTargeting/NuGetizer.props`, and does not place MSBuild assets under `content/`.