### PR TITLE
fix: make NuGetizer self-pack robust so build/ assets always land correctly

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -39,7 +39,7 @@
     <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
   </PropertyGroup>
 
-  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)') And '$(NuGetize)' != 'true'" />
 
   <PropertyGroup>
     <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->

--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -13,4 +13,24 @@
     <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>
 
+  <!-- 
+    Robust Pack delegation for NuGetizer itself (and similar PackFolder=build projects).
+    "dotnet pack" (and GeneratePackageOnBuild=true scenarios) must go through NuGetize=true
+    so that NuGetizer's inference + PackFolder=build logic classifies the *.props/*.targets
+    into build/ + buildMultiTargeting/ instead of the SDK pack's default content/contentFiles handling.
+    This definition is late (in Directory.targets) so it wins over the SDK pack target's definition
+    that was forcibly imported to workaround PackageId defaults.
+  -->
+  <Target Name="Pack"
+          Condition="'$(NuGetize)' != 'true' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive' or '$(MSBuildProjectName)' == 'NuGetizer.Tasks')"
+          Returns="@(PackOutput)">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             UnloadProjectsOnCompletion="true"
+             UseResultsCache="false"
+             Properties="NuGetize=true;GeneratePackageOnBuild=false"
+             Targets="Pack">
+      <Output TaskParameter="TargetOutputs" ItemName="PackOutput" />
+    </MSBuild>
+  </Target>
+
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.Pack.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.Pack.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- GeneratePackageOnBuild=false is used by VS when right-click Pack is used :) -->
-  <Target Name="Pack" Condition="'$(GeneratePackageOnBuild)' == 'false' AND '$(NuGetize)' != 'true'" Returns="@(PackOutput)">
+  <Target Name="Pack" Condition="'$(NuGetize)' != 'true'" Returns="@(PackOutput)">
     <!-- Typically called in the IDE when we run Pack context menu. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" UnloadProjectsOnCompletion="true" UseResultsCache="false"
              Properties="NuGetize=true" Targets="Pack">

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.csproj
@@ -45,6 +45,14 @@
 
   <ItemGroup>
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Pack="true" />
+    <!-- 
+      Explicit PackagePath for our build assets so they reliably go under build/ (not content)
+      no matter if inference or the SDK pack ends up driving the actual packaging.
+      PackagePath takes precedence.
+    -->
+    <None Update="*.props;*.targets;*.tasks;NuGetizer.*.props;NuGetizer.*.targets;NuGetizer.*.tasks;dotnet-nugetize.*;NuGetizer.Shared.targets;NuGetizer.Cleanup.targets;NuGetizer.Compatibility.props;NuGetizer.Inference.*;NuGetizer.Authoring.*;NuGetizer.PackageValidation.targets;NuGetizer.PackageMetadata.targets;NuGetizer.Version.props;NuGetizer.Tasks.Pack.targets"
+          PackagePath="build\%(Filename)%(Extension)" />
+    <!-- Specific overrides for the buildMultiTargeting copies -->
     <None Update="NuGetizer.MultiTargeting.props" PackagePath="buildMultiTargeting\NuGetizer.props" />
     <None Update="NuGetizer.MultiTargeting.targets" PackagePath="buildMultiTargeting\NuGetizer.targets" />
     <None Include="NuGetizer.PackageMetadata.targets;dotnet-nugetize.props;dotnet-nugetize.targets" PackagePath="buildMultiTargeting\%(Filename)%(Extension)" Pack="true" />
@@ -60,7 +68,7 @@
     <EmbeddedResource Update="Resources.resx" Generator="" />
   </ItemGroup>
   
-  <Import Project="NuGetizer.Tasks.Pack.targets" Condition="'$(GeneratePackageOnBuild)' == 'false' AND '$(NuGetize)' != 'true'" />
+  <Import Project="NuGetizer.Tasks.Pack.targets" Condition="'$(NuGetize)' != 'true'" />
   <Import Project="NuGetizer.Tasks.targets" />
   <Import Project="..\ILRepack.targets" />
 </Project>


### PR DESCRIPTION
### Problem
NuGetizer 1.4.8 (and builds after the PackageId / duplicate-import sync work) was publishing a broken package: its own `build/*.props`, `build/*.targets`, `NuGetizer.*`, etc. ended up under `content/` + `contentFiles/any/...` instead of `build/` (and `buildMultiTargeting/`).

This broke downstream users because the MSBuild targets/props were not discovered.

### Root cause
- "dotnet pack" (and `GeneratePackageOnBuild=true`) skipped the old delegation condition.
- The forced import of the real `NuGet.Build.Tasks.Pack.targets` (added to workaround SDK PackageId defaults) made the SDK pack path win for `NuGetizer.Tasks`.
- No explicit location metadata + inference falling back to `DefaultPackFolder=content` for `None`/`Content` items.

### Fix (robust)
* Add explicit `PackagePath="build\..."` (with overrides for the `buildMultiTargeting` copies) on all the build support files. `PackagePath` is honored by both NuGetizer and the SDK pack.
* Add a *late* `Pack` target delegator in `Directory.targets` (after the SDK pack import) that forces the `NuGetize=true` path for `PackFolder=build` projects.
* Condition the manual real-pack-targets import on `NuGetize != 'true'`.
* Loosen the small delegation conditions so it is no longer tied to `GeneratePackageOnBuild=='false'`.

These changes make the layout of NuGetizer's own assets independent of how `dotnet pack` / IDE pack / Directory.Build changes are made in the future.

Fixes the 1.4.8 layout regression reported for the published package.
