### PR TITLE
fix: ensure NuGetizer dogfooding package is always produced by CI pack + sleet

### DIFF
--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -6,9 +6,6 @@
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(NuGetize)' == 'true' or '$(GeneratePackageOnBuild)' != ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)NuGetizer.Tasks\$(OutputPath)NuGetizer.targets"
-          Condition="($(IsPackable) == 'true' OR $(PackFolder) != '') AND $(NuGetize) == 'true'" />
-
   <PropertyGroup>
     <PackFolderKindFile>$(IntermediateOutputPath)PackFolderKind.g$(DefaultLanguageSourceExtension)</PackFolderKindFile>
   </PropertyGroup>
@@ -20,6 +17,9 @@
     into build/ + buildMultiTargeting/ instead of the SDK pack's default content/contentFiles handling.
     This definition is late (in Directory.targets) so it wins over the SDK pack target's definition
     that was forcibly imported to workaround PackageId defaults.
+    IMPORTANT: declare the delegator BEFORE the conditional engine import below. When NuGetize=true
+    the engine import brings in the real Pack target later in processing, so it wins. When not NuGetize,
+    the delegator is the active definition and redirects.
   -->
   <Target Name="Pack"
           Condition="'$(NuGetize)' != 'true' and ('$(PackFolder)' == 'build' or '$(PackFolder)' == 'buildTransitive' or '$(MSBuildProjectName)' == 'NuGetizer.Tasks')"
@@ -32,5 +32,8 @@
       <Output TaskParameter="TargetOutputs" ItemName="PackOutput" />
     </MSBuild>
   </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)NuGetizer.Tasks\$(OutputPath)NuGetizer.targets"
+          Condition="($(IsPackable) == 'true' OR $(PackFolder) != '') AND $(NuGetize) == 'true'" />
 
 </Project>

--- a/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
+++ b/src/NuGetizer.Tasks/NuGetizer.Tasks.targets
@@ -36,7 +36,8 @@
     <PropertyGroup>
       <XmlNs>&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;</XmlNs>
     </PropertyGroup>
-    <XmlPoke Namespaces="$(XmlNs)"
+    <XmlPoke Condition="Exists('$(OutputPath)NuGetizer.Version.props')"
+				 Namespaces="$(XmlNs)"
 				 XmlInputPath="$(OutputPath)NuGetizer.Version.props"
 				 Query="/msb:Project/msb:PropertyGroup/msb:PackVersion"
 				 Value="$(Version)"/>


### PR DESCRIPTION
The recent self-pack robustness changes (see #1878 / 1894e2f) caused the late Pack delegator in Directory.targets to override the NuGetizer engine'\''s Pack target even when NuGetize=true.

As a result, the `📦 pack` step in both `build.yml` (on push to main) and `publish.yml` produced no .nupkg files in `bin/`. The subsequent `🚀 sleet` step then saw a missing/empty bin directory:

    [System.IO.FileNotFoundException] Unable to find '\''...\\bin'\''.
    No packages found

(See the failing job: https://github.com/devlooped/nugetizer/actions/runs/28137348651/job/83326971793)

We must **always** produce a dogfooding package on CI builds so the sleet publish step has something to push.

### Root cause
* The delegator `<Target Name="Pack" Condition="...">` was declared *after* the conditional `<Import>` of the NuGetizer engine (NuGetizer.targets + Shared.targets).
* When `NuGetize=true` (via the delegator'\''s recursive MSBuild or direct), the engine brought in its `Pack` definition, but the later delegator declaration in the same file overrode it.
* With the nugetizer `Pack` never executing, no package was emitted.

### Fix
* Re-order so the delegator Target is declared **before** the conditional engine import inside `src/Directory.targets`.  
  - When `NuGetize=true` the engine'\''s `Pack` (with `GetPackageContents` + `CreatePackage`) is the last definition and wins.  
  - When `NuGetize != true` (normal `dotnet pack` on a `PackFolder=build` project or NuGetizer.Tasks itself) the delegator is active and redirects via `NuGetize=true`.
* Guard the `XmlPoke` of the copied `NuGetizer.Version.props` so a clean pack (no pre-built outputs) does not hard-fail. CI still does the prerequisite `msbuild -r` of the test project (which populates `bin/Release` under NuGetizer.Tasks) before the pack step, so the poke + version stamping still happens in the normal flow.

### Verification performed
* Reproduced the exact steps from `build.yml` (pre-build of tests + `dotnet pack -m:1 -c:Release`) → package now appears in `bin/`.
* Reproduced the steps from `publish.yml` (scenario restores + `msbuild -r` in `src/NuGetizer.Tests` + plain `dotnet pack`) → package produced.
* Confirmed the emitted `NuGetizer.*.nupkg` contains assets under `build/` (not `content/`) as required by the previous robustness fix.

This change guarantees that every time the windows build job runs, `pack` emits the dogfood package and `sleet` has real artifacts to publish.
